### PR TITLE
Proxy requests to backend on port 9082

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -12,7 +12,7 @@
   }
 
   handle_path /backend/* {
-    reverse_proxy backend:9084 {
+    reverse_proxy backend:9082 {
       header_up Host {upstream_hostport}
       header_up X-Real-IP {remote}
     }


### PR DESCRIPTION
This is the default for a while now, see `backend/.example.env`.