### PR TITLE
fix hmr setup and document usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,34 @@ Profiles can be used as follows:
 docker compose --profile blockexplorer --profile smart-contracts-eth up --build
 ```
 
+### Local development - Frontend with Hot Module Reload (HMR)
+Especially while working on the frontend, HMR in local development enables you to instantly see your changes without having to rebuild the project or wait ages.
+
+First a change in the caddy file (`caddy/Caddyfile`) is required.
+
+```yaml
+# change
+reverse_proxy frontend:9085
+# to
+reverse_proxy host.docker.internal:9085
+```
+
+Afterwards docker can be started up again
+```shell
+docker compose --profile platform up --build
+
+# Switch to a different tab / terminal and shut down the frontend
+docker compose stop frontend
+```
+
+Move to your frontend folder (assuming you are in the root flatfeestack dir) and execute the new pnpm script
+```shell
+cd frontend
+pnpm run hmr
+```
+
+Afterwards you can visit the same URL and use the frontend but this time with HMR.
+
 ## Register a user for the platform
 
 To register a user:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
     }
   },
   "scripts": {
-    "hmr": "vite --host",
+    "hmr": "MODE=hmr vite --host",
     "dev": "concurrently --kill-others \"node server\" \"npx npm-watch\"",
     "build": "MODE=dev vite build",
     "prod": "MODE=prod vite build",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -7,9 +7,9 @@ const mode = process.env.MODE || "dev";
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
-    //svelte(),
     svelte({ compilerOptions: { hydratable: true } }),
-    ssr({ prerender: true }),
+
+    mode !== "hmr" ? ssr({ prerender: true }) : {},
 
     compress({
       algorithm: "brotliCompress",


### PR DESCRIPTION
There are currently still some problems; most of the routes work now without a problem, but 
- `/user/payments`
- `/user/settings`

Currently can't be directly accessed, as they throw an error that causes vite / vite HMR to fatally fail.

The problem is the access to the store within the `$` label syntax, as the store at that point isn't yet ready with the data to be accessed.

I theoretically found a workaround for the `/user/settings`, although it's not the cleanest, but for the `/user/payments`, I would need to invest some more time or rewrite different parts. The question for me now is, how much time/effort should be put into this, or would it be alright for the moment to leave it like it is, as the other routes are accessible and when switching via the navigation, there is no problem?