### PR TITLE
Hide postal code for Stripe payment

### DIFF
--- a/frontend/src/components/PaymentTabs/FiatTab.svelte
+++ b/frontend/src/components/PaymentTabs/FiatTab.svelte
@@ -37,7 +37,7 @@
     if (!cardElement) {
       console.log("called create");
       let elements = stripe.elements();
-      cardElement = elements.create("card");
+      cardElement = elements.create("card", { hidePostalCode: true });
       cardElement.mount(card);
       cardElement.on("change", (e) => {
         if (e.error) {


### PR DESCRIPTION
I'm note sure what kind of postal code is the default, but entering Swiss postal codes never worked. But since we don't need to have this information, we can hide the field.