### PR TITLE
remove urls in text field from badges

### DIFF
--- a/frontend/src/routes/Badges.svelte
+++ b/frontend/src/routes/Badges.svelte
@@ -93,8 +93,6 @@
         <thead>
           <tr>
             <th>Name</th>
-            <th>URL</th>
-            <th>Repos</th>
             <th>Description</th>
             <th>Unclaimed Sponsoring</th>
             <th>Graph</th>
@@ -103,11 +101,7 @@
         <tbody>
           {#each contributionSummaries as cs}
             <tr>
-              <td>{cs.repo.name}</td>
-              <td><a href={cs.repo.url}>{cs.repo.url}</a></td>
-              <td>
-                <a href={cs.repo.gitUrl}>{cs.repo.gitUrl}</a>
-              </td>
+              <td><a href={cs.repo.url}>{cs.repo.name}</a></td>
               <td>{cs.repo.description}</td>
               <td
                 >{#each Object.entries(cs.currencyBalance) as [key, value]}{formatBalance(


### PR DESCRIPTION
just linked the repo name instead


now a little simpler and not filled with (nearly) the same URL twice
<img width="1395" alt="Screenshot 2023-04-29 at 17 07 29" src="https://user-images.githubusercontent.com/85156725/235309794-107c4d47-9a7a-4985-bc47-11052f32c13c.png">
