### PR TITLE
Optimise loading of voting slots

### DIFF
--- a/frontend/src/ts/proposalStore.ts
+++ b/frontend/src/ts/proposalStore.ts
@@ -64,7 +64,11 @@ export const votingSlots = derived<Readable<null | Contract>, null | number[]>(
               )
             )
           ).then((slots: BigNumber[]) => {
-            set(slots.map((slot) => slot.toNumber()));
+            const sortedSlots = slots
+              .map((slot) => slot.toNumber())
+              .sort((slot1, slot2) => slot2 - slot1); // sort descending, slot with latest start to appear first
+
+            set(sortedSlots);
           });
         })
         .catch((reason) => {


### PR DESCRIPTION
This PR optimises the loading procedure for voting slots on the main DAO page.

I think an issue with our previous implementation was the fact that we left the slot numbers retrieved from the chain unsorted. The slots were sorted manually in the component after all meta information had been calculated, which was somewhat compute-heavy.

In this commit,  I sort the slot numbers in the store directly, descending by default. Then, in the component itself, using `Promise.all`, the metadata is calculated and the component updated once - this should get rid of this "plop" effect we have right now were the votings slots were shoved into the view one by one.

Loading can be optimised further in a later step, where pagination could be added.