### PR TITLE
Show user associated with forum post / comment

### DIFF
--- a/backend/api/users.go
+++ b/backend/api/users.go
@@ -11,6 +11,28 @@ import (
 	"net/http"
 )
 
+func GetUserById(w http.ResponseWriter, r *http.Request) {
+	params := mux.Vars(r)
+	userId := params["id"]
+	convertedUserId, err := uuid.Parse(userId)
+
+	if err != nil {
+		utils.WriteErrorf(w, http.StatusBadRequest, "Invalid user ID: %v", err)
+	}
+
+	user, err := db.FindPublicUserById(convertedUserId)
+
+	if user == nil {
+		utils.WriteErrorf(w, http.StatusNotFound, "User not found")
+	} else if err != nil {
+		utils.WriteErrorf(w, http.StatusInternalServerError, "Could not fetch user: %v", err)
+	} else {
+		utils.WriteJson(w, user)
+	}
+
+	return
+}
+
 func GetMyUser(w http.ResponseWriter, _ *http.Request, user *db.UserDetail) {
 	utils.WriteJson(w, user)
 }

--- a/backend/api/users_test.go
+++ b/backend/api/users_test.go
@@ -1,0 +1,66 @@
+package api
+
+import (
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetUserById(t *testing.T) {
+	t.Run("should return user", func(t *testing.T) {
+		setup()
+		defer teardown()
+
+		userDetail := insertTestUser(t, "hello@world.com")
+		request, _ := http.NewRequest(http.MethodPost, "/users/"+userDetail.Id.String(), nil)
+		response := httptest.NewRecorder()
+		vars := map[string]string{
+			"id": userDetail.Id.String(),
+		}
+		request = mux.SetURLVars(request, vars)
+
+		GetUserById(response, request)
+
+		assert.Equal(t, 200, response.Code)
+		body, _ := io.ReadAll(response.Body)
+		assert.Containsf(t, string(body), "\"image\":null}\n", "error message %s")
+	})
+
+	t.Run("returns 400 if id format is faulty", func(t *testing.T) {
+		setup()
+		defer teardown()
+
+		request, _ := http.NewRequest(http.MethodPost, "/users/hello", nil)
+		response := httptest.NewRecorder()
+		vars := map[string]string{
+			"id": "hello",
+		}
+		request = mux.SetURLVars(request, vars)
+
+		GetUserById(response, request)
+
+		assert.Equal(t, 400, response.Code)
+	})
+
+	t.Run("returns 404 if user does not exist", func(t *testing.T) {
+		setup()
+		defer teardown()
+
+		uuid := uuid.New()
+
+		request, _ := http.NewRequest(http.MethodPost, "/users/"+uuid.String(), nil)
+		response := httptest.NewRecorder()
+		vars := map[string]string{
+			"id": uuid.String(),
+		}
+		request = mux.SetURLVars(request, vars)
+
+		GetUserById(response, request)
+
+		assert.Equal(t, 404, response.Code)
+	})
+}

--- a/backend/backend.yaml
+++ b/backend/backend.yaml
@@ -398,6 +398,30 @@ paths:
                 $ref: '#/components/schemas/PayoutResponse'
         '400':
           description: Bad Request
+  /users/{id}:
+    get:
+      tags:
+        - Users
+      parameters:
+        - name: id
+          in: query
+          required: true
+          schema:
+            type: string
+            format: uuid
+      security:
+        - bearerAuth: [ User ]
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PublicUser'
+        '400':
+          description: Bad Request
   /repos/search:
     get:
       tags:
@@ -1241,3 +1265,16 @@ components:
         - amount
         - encodedUserId
         - signature
+
+    PublicUser:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          nullable: true
+        image:
+          type: string
+          nullable: true

--- a/backend/db/users.go
+++ b/backend/db/users.go
@@ -29,6 +29,12 @@ type UserDetail struct {
 	Role               *string `json:"role,omitempty"`
 }
 
+type PublicUser struct {
+	Id    uuid.UUID `json:"id"`
+	Name  *string   `json:"name,omitempty"`
+	Image *string   `json:"image"`
+}
+
 func FindAllEmails() ([]string, error) {
 	emails := []string{}
 	s := `SELECT email from users`
@@ -77,6 +83,23 @@ func FindUserById(uid uuid.UUID) (*UserDetail, error) {
                         WHERE id=$1`, uid).
 		Scan(&u.Id, &u.StripeId, &u.InvitedId, &u.PaymentMethod, &u.Last4,
 			&u.StripeClientSecret, &u.Email, &u.Name, &u.Image, &u.Seats, &u.Freq, &u.CreatedAt)
+	switch err {
+	case sql.ErrNoRows:
+		return nil, nil
+	case nil:
+		return &u, nil
+	default:
+		return nil, err
+	}
+}
+
+func FindPublicUserById(uid uuid.UUID) (*PublicUser, error) {
+	var u PublicUser
+	err := db.
+		QueryRow(`SELECT id, name, image                       
+                        FROM users 
+                        WHERE id=$1`, uid).
+		Scan(&u.Id, &u.Name, &u.Image)
 	switch err {
 	case sql.ErrNoRows:
 		return nil, nil

--- a/backend/main.go
+++ b/backend/main.go
@@ -246,6 +246,10 @@ func main() {
 	router.HandleFunc("/users/me/stripe/{freq}/{seats}", jwtAuthUser(api.StripePaymentInitial)).Methods(http.MethodPut)
 	router.HandleFunc("/users/me/nowPayment/{freq}/{seats}", jwtAuthUser(api.NowPayment)).Methods(http.MethodPost)
 	router.HandleFunc("/users/me/sponsored-users", jwtAuthUser(api.StatusSponsoredUsers)).Methods(http.MethodPost)
+
+	// get public user
+	router.HandleFunc("/users/{id}", api.GetUserById).Methods(http.MethodGet)
+
 	//contributions
 	router.HandleFunc("/users/contrib-snd", jwtAuthUser(api.ContributionsSend)).Methods(http.MethodPost)
 	router.HandleFunc("/users/contrib-rcv", jwtAuthUser(api.ContributionsRcv)).Methods(http.MethodPost)

--- a/frontend/src/components/DAO/DiscussionListItem.svelte
+++ b/frontend/src/components/DAO/DiscussionListItem.svelte
@@ -3,6 +3,7 @@
   import type { Post } from "../../types/forum";
   import formatDateTime from "../../utils/formatDateTime";
   import StatusSpan from "./discussions/StatusSpan.svelte";
+  import { users } from "../../ts/userStore";
 
   export let post: Post;
 </script>
@@ -39,7 +40,12 @@
       <StatusSpan {post} />
     </p>
     <p>
-      Created on {formatDateTime(new Date(post.created_at))} by {post.author}
+      {#await users.get(post.author)}
+        ...
+      {:then user}
+        Created on {formatDateTime(new Date(post.created_at))} by {user.name ||
+          "[unknown]"}
+      {/await}
     </p>
   </div>
 

--- a/frontend/src/components/DAO/discussions/DiscussionThreadItem.svelte
+++ b/frontend/src/components/DAO/discussions/DiscussionThreadItem.svelte
@@ -5,6 +5,7 @@
   import { timeSince } from "../../../ts/services";
   import type { Comment, Post } from "../../../types/forum";
   import ThreadItemBox from "../ThreadItemBox.svelte";
+  import { users } from "../../../ts/userStore";
 
   export let deleteItem: () => void;
   export let discussionOpen: boolean;
@@ -17,6 +18,12 @@
     margin-right: 0.5rem;
   }
 
+  .image {
+    border-radius: 9999px;
+    height: 2rem;
+    width: 2rem;
+  }
+
   p {
     margin: 0.1rem;
   }
@@ -24,7 +31,22 @@
 
 <ThreadItemBox>
   <div class="border-bottom flex justify-between">
-    <p class="bold">{item.author}</p>
+    <div class="flex gap-3 items-center">
+      {#await users.get(item.author)}
+        ...
+      {:then user}
+        {#if user.image}
+          <img
+            class="image"
+            src={user.image}
+            alt={`Profile picture of ${user.name || "[unknown]"}`}
+          />
+        {:else}
+          <div class="bg-green image" />
+        {/if}
+        <p class="bold">{user.name || "[unknown]"}</p>
+      {/await}
+    </div>
     <div class="color-secondary-500 flex gap-3 items-center mr-4">
       <div>
         <p>

--- a/frontend/src/ts/api.ts
+++ b/frontend/src/ts/api.ts
@@ -16,6 +16,7 @@ import type {
   User,
   UserStatus,
   PayoutResponse,
+  PublicUser,
 } from "../types/backend";
 import type { Token } from "../types/auth";
 import { token } from "./mainStore";
@@ -201,6 +202,8 @@ export const API = {
       backendToken
         .post(`users/me/request-payout/${targetCurrency}`)
         .json<PayoutResponse>(),
+    getUser: (userId: string) =>
+      backendToken.get(`users/${userId}`).json<PublicUser>(),
   },
   repos: {
     search: (s: string) =>

--- a/frontend/src/ts/userStore.ts
+++ b/frontend/src/ts/userStore.ts
@@ -1,0 +1,25 @@
+import { get, writable } from "svelte/store";
+import type { PublicUser } from "../types/backend";
+import { API } from "./api";
+
+const usersStore = writable<PublicUser[]>([]);
+
+export const users = {
+  subscribe: usersStore.subscribe,
+  async get(userId: string): Promise<PublicUser> {
+    const values = get(usersStore);
+    const result = values.find(({ id }) => userId === id);
+    if (result) {
+      return result;
+    } else {
+      return await Promise.resolve(
+        API.user.getUser(userId).then((user: PublicUser) => {
+          usersStore.update((items) => {
+            return [...items, user];
+          });
+          return user;
+        })
+      );
+    }
+  },
+};

--- a/frontend/src/types/backend.ts
+++ b/frontend/src/types/backend.ts
@@ -34,3 +34,5 @@ export type PaymentResponse = components["schemas"]["PaymentResponse"];
 export type ChartDataTotal = components["schemas"]["Data"];
 
 export type PayoutResponse = components["schemas"]["PayoutResponse"];
+
+export type PublicUser = components["schemas"]["PublicUser"];

--- a/frontend/src/types/generated-backend-types.ts
+++ b/frontend/src/types/generated-backend-types.ts
@@ -100,6 +100,14 @@ export interface paths {
       };
     };
   };
+  "/users/me/clear/name": {
+    put: {
+      responses: {
+        /** @description OK */
+        200: never;
+      };
+    };
+  };
   "/users/me/image": {
     post: {
       requestBody: {
@@ -300,6 +308,25 @@ export interface paths {
         200: {
           content: {
             "application/json": components["schemas"]["PayoutResponse"];
+          };
+        };
+        /** @description Bad Request */
+        400: never;
+      };
+    };
+  };
+  "/users/{id}": {
+    get: {
+      parameters: {
+        query: {
+          id: string;
+        };
+      };
+      responses: {
+        /** @description OK */
+        200: {
+          content: {
+            "application/json": (components["schemas"]["PublicUser"])[];
           };
         };
         /** @description Bad Request */
@@ -871,6 +898,12 @@ export interface components {
       encodedUserId: string;
       /** Format: byte */
       signature: string;
+    };
+    PublicUser: {
+      /** Format: uuid */
+      id?: string;
+      name?: string | null;
+      image?: string | null;
     };
   };
   responses: never;


### PR DESCRIPTION
This PR adds a new endpoint to the backend which allows to retrieve the username and image for a given ID.

This is then displayed at a couple of places in the forum. First the index page:

![Screenshot from 2023-05-05 17-07-31](https://user-images.githubusercontent.com/7010698/236496880-96a90d1b-9e5a-4846-9726-293f95b3b5f2.png)

And at post level:

![Screenshot from 2023-05-05 17-07-18](https://user-images.githubusercontent.com/7010698/236496951-ac214583-be75-4a55-8b36-152c91be63bf.png)

If a user has no image, a colored div is displayed instead.

![Screenshot from 2023-05-05 17-06-57](https://user-images.githubusercontent.com/7010698/236497063-d462391d-491c-49a1-bca5-18eef8180a74.png)