### PR TITLE
allow actual error messages to be displayed

### DIFF
--- a/backend/utils/utils.go
+++ b/backend/utils/utils.go
@@ -53,7 +53,11 @@ func WriteErrorf(w http.ResponseWriter, code int, format string, a ...interface{
 	w.Header().Set("Pragma", "no-cache")
 	w.WriteHeader(code)
 	if debug {
-		w.Write([]byte(`{"error":"` + msg + `"}`))
+		msgEnc, err := json.Marshal(msg)
+		if err != nil {
+			log.Errorf("error while trying to encode msg:  %v", msg)
+		}
+		w.Write([]byte(`{"error":` + string(msgEnc) + `}`))
 	}
 }
 

--- a/frontend/src/routes/Admin.svelte
+++ b/frontend/src/routes/Admin.svelte
@@ -38,14 +38,18 @@
   };
 
   const handleWarp = async (hours: number) => {
-    const p1 = API.user.timeWarp(hours);
-    const p2 = API.authToken.timeWarp(hours);
-    const p3 = refresh();
+    try {
+      const p1 = API.user.timeWarp(hours);
+      const p2 = API.authToken.timeWarp(hours);
+      const p3 = refresh();
 
-    const res = await p2;
-    storeToken(res);
-    await p1;
-    await p3;
+      const res = await p2;
+      storeToken(res);
+      await p1;
+      await p3;
+    } catch (e) {
+      $error = e;
+    }
   };
 
   const payout = async () => {

--- a/frontend/src/routes/ConfirmForgot.svelte
+++ b/frontend/src/routes/ConfirmForgot.svelte
@@ -21,7 +21,7 @@
       password = "";
     } catch (e) {
       isSubmitting = false;
-      console.log(e);
+      error = e;
     }
   }
 </script>

--- a/frontend/src/routes/Forgot.svelte
+++ b/frontend/src/routes/Forgot.svelte
@@ -17,11 +17,9 @@
       email = "";
       info =
         "Your email is on the way. To enable your account, click on the link in the email.";
-      console.log(res);
     } catch (e) {
       isSubmitting = false;
       error = "Something went wrong. Please try again.";
-      console.log(e);
     }
   }
 </script>

--- a/frontend/src/routes/Invitations.svelte
+++ b/frontend/src/routes/Invitations.svelte
@@ -78,8 +78,7 @@
       await res1;
       await res2;
     } catch (e) {
-      $error =
-        "Duplicate email address. Can't invite the same address multiple times.";
+      $error = e;
     } finally {
       isAddInviteSubmitting = false;
     }

--- a/frontend/src/routes/Settings.svelte
+++ b/frontend/src/routes/Settings.svelte
@@ -67,7 +67,7 @@
       gitEmails = [...gitEmails, ge];
       newEmail = "";
     } catch (e) {
-      $error = "Duplicate email address. Email can only be used once.";
+      $error = e;
     }
   }
 

--- a/frontend/src/ts/api.ts
+++ b/frontend/src/ts/api.ts
@@ -66,11 +66,17 @@ const restTimeout = 5000;
 const authToken = ky.create({
   prefixUrl: "/auth",
   timeout: restTimeout,
+  throwHttpErrors: false,
   hooks: {
     beforeRequest: [async (request) => addToken(request)],
     afterResponse: [
-      async (request: Request, options: any, response: Response) =>
-        refreshToken(request, options, response),
+      async (request: Request, options: any, response: Response) => {
+        refreshToken(request, options, response);
+        const body = await response.json();
+        if (body.error) {
+          throw new Error(body.error);
+        }
+      },
     ],
   },
 });
@@ -78,11 +84,17 @@ const authToken = ky.create({
 const backendToken = ky.create({
   prefixUrl: "/backend",
   timeout: restTimeout,
+  throwHttpErrors: false,
   hooks: {
     beforeRequest: [async (request) => addToken(request)],
     afterResponse: [
-      async (request: Request, options: any, response: Response) =>
-        refreshToken(request, options, response),
+      async (request: Request, options: any, response: Response) => {
+        refreshToken(request, options, response);
+        const body = await response.json();
+        if (body.error) {
+          throw new Error(body.error);
+        }
+      },
     ],
   },
 });


### PR DESCRIPTION
before always standard http error messages were displayed. in a lot of cases this is fine, but in a fn that throws multiple errors, it might be helpful to show the user where exactly it went wrong.

need to encode the msg as otherwise it will end up being invalid json and not being able to be displayed