### PR TITLE
fix sending git email, add mail-template agains

### DIFF
--- a/backend/api/email.go
+++ b/backend/api/email.go
@@ -6,10 +6,10 @@ import (
 	"backend/utils"
 	"encoding/base32"
 	"encoding/json"
+	"net/http"
+
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
-	"net/http"
-	"net/url"
 )
 
 func GetMyConnectedEmails(w http.ResponseWriter, _ *http.Request, user *db.UserDetail) {
@@ -57,8 +57,7 @@ func AddGitEmail(w http.ResponseWriter, r *http.Request, user *db.UserDetail) {
 		return
 	}
 
-	email := url.QueryEscape(body.Email)
-	clnt.SendAddGit(email, addGitEmailToken, lang(r))
+	clnt.SendAddGit(body.Email, addGitEmailToken, lang(r))
 }
 
 func RemoveGitEmail(w http.ResponseWriter, r *http.Request, user *db.UserDetail) {

--- a/backend/utils/utils.go
+++ b/backend/utils/utils.go
@@ -6,15 +6,16 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
-	"github.com/alecthomas/template"
-	"github.com/google/uuid"
-	log "github.com/sirupsen/logrus"
-	"github.com/spaolacci/murmur3"
 	"math/big"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
+
+	"github.com/alecthomas/template"
+	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
+	"github.com/spaolacci/murmur3"
 )
 
 var (
@@ -164,7 +165,7 @@ func GetFactor(currency string) (*big.Int, error) {
 
 func ParseTemplate(filename string, other map[string]string) string {
 	textMessage := ""
-	tmplPlain, err := template.ParseFiles(filename)
+	tmplPlain, err := template.ParseFiles("mail-templates/" + filename)
 	if err == nil {
 		var buf bytes.Buffer
 		err = tmplPlain.Execute(&buf, other)


### PR DESCRIPTION
- add prefix for mail templates
- remove url encoding for email, causing sendgrid not being able to send it