### PR TITLE
Test payment-related endpoints

### DIFF
--- a/backend/api/paymentStripe.go
+++ b/backend/api/paymentStripe.go
@@ -213,7 +213,7 @@ func StripeWebhook(w http.ResponseWriter, req *http.Request) {
 	case "payment_intent.succeeded":
 		externalId, feePrm, err := parseStripeData(event.Data.Raw)
 		if err != nil {
-			log.Printf("Parer err from stripe: %v\n", err)
+			log.Printf("Parser err from stripe: %v\n", err)
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
@@ -243,7 +243,7 @@ func StripeWebhook(w http.ResponseWriter, req *http.Request) {
 		//again
 		externalId, _, err := parseStripeData(event.Data.Raw)
 		if err != nil {
-			log.Printf("Parer err from stripe: %v\n", err)
+			log.Printf("Parser err from stripe: %v\n", err)
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
@@ -277,7 +277,7 @@ func StripeWebhook(w http.ResponseWriter, req *http.Request) {
 		}
 		externalId, _, err := parseStripeData(event.Data.Raw)
 		if err != nil {
-			log.Printf("Parer err from stripe: %v\n", err)
+			log.Printf("Parser err from stripe: %v\n", err)
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}

--- a/backend/api/paymentStripe_test.go
+++ b/backend/api/paymentStripe_test.go
@@ -1,0 +1,85 @@
+package api
+
+import (
+	"backend/db"
+	"backend/utils"
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stripe/stripe-go/v74"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestPostHookStripe(t *testing.T) {
+	stripeWebhookSecretKey = "webhooksecret"
+
+	t.Run("stripe confirms successful payment", func(t *testing.T) {
+		setup()
+		defer teardown()
+
+		userDetail := insertTestUser(t, "hello@world.com")
+		payInEvent := insertPayInEvent(t, uuid.New(), userDetail.Id, db.PayInRequest, "USD", Plans[0].PriceBase, 1, Plans[0].Freq)
+
+		metadata := make(map[string]string)
+		metadata["userId"] = userDetail.Id.String()
+		metadata["externalId"] = payInEvent.ExternalId.String()
+		metadata["freq"] = strconv.FormatInt(365, 10)
+		metadata["seats"] = strconv.Itoa(1)
+		metadata["fee"] = strconv.FormatInt(40, 10)
+
+		paymentIntent := stripe.PaymentIntent{
+			Amount:   utils.UsdBaseToCent(Plans[0].PriceBase),
+			Metadata: metadata,
+		}
+
+		jsonBytes, err := json.Marshal(paymentIntent)
+		require.Nil(t, err)
+
+		eventData := stripe.EventData{
+			Raw: json.RawMessage(jsonBytes),
+		}
+		event := stripe.Event{
+			APIVersion: "2022-11-15",
+			Data:       &eventData,
+			Type:       "payment_intent.succeeded",
+		}
+		body, err := json.Marshal(event)
+		require.Nil(t, err)
+
+		timestamp := strconv.FormatInt(time.Now().Unix(), 10)
+		hasher := hmac.New(sha256.New, []byte("webhooksecret"))
+		hasher.Write(append([]byte(timestamp+"."), body...))
+		hmacBytes := hasher.Sum(nil)
+		hmacString := hex.EncodeToString(hmacBytes)
+
+		request, _ := http.NewRequest(http.MethodPost, "/hooks/stripe", bytes.NewReader(body))
+		request.Header.Set("Stripe-Signature", "t="+timestamp+",v1="+hmacString)
+		response := httptest.NewRecorder()
+
+		StripeWebhook(response, request)
+
+		assert.Equal(t, 200, response.Code)
+
+		// this should create two events now
+		// one that confirms the pay in
+		// and another one that stores the fees
+		successPayIn, err := db.FindPayInExternal(payInEvent.ExternalId, db.PayInSuccess)
+		assert.Nil(t, err)
+		assert.NotNil(t, successPayIn)
+		assert.Equal(t, int64(120451199), successPayIn.Balance.Int64())
+
+		feePayIn, err := db.FindPayInExternal(payInEvent.ExternalId, db.PayInFee)
+		assert.Nil(t, err)
+		assert.NotNil(t, feePayIn)
+		assert.Equal(t, int64(5018801), feePayIn.Balance.Int64())
+	})
+}

--- a/backend/api/payment_test.go
+++ b/backend/api/payment_test.go
@@ -1,0 +1,122 @@
+package api
+
+import (
+	"backend/db"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"io"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestGetUserBalance(t *testing.T) {
+	t.Run("user made no payments", func(t *testing.T) {
+		setup()
+		defer teardown()
+
+		userDetail := insertTestUser(t, "hello@flatfeestack.io")
+		request, _ := http.NewRequest(http.MethodPost, "/users/me/balance", nil)
+		response := httptest.NewRecorder()
+
+		UserBalance(response, request, userDetail)
+
+		assert.Equal(t, 200, response.Code)
+
+		body, _ := io.ReadAll(response.Body)
+		assert.Equal(t, "[]\n", string(body))
+	})
+
+	t.Run("user made a pay-in but did not distribute anything", func(t *testing.T) {
+		setup()
+		defer teardown()
+
+		userDetail := insertTestUser(t, "hello@flatfeestack.io")
+		insertPayInEvent(t, uuid.New(), userDetail.Id, db.PayInSuccess, "USD", 12, 2, 2)
+
+		request, _ := http.NewRequest(http.MethodPost, "/users/me/balance", nil)
+		response := httptest.NewRecorder()
+
+		UserBalance(response, request, userDetail)
+
+		assert.Equal(t, 200, response.Code)
+
+		body, _ := io.ReadAll(response.Body)
+		assert.Equal(t, "[{\"currency\":\"USD\",\"balance\":12}]\n", string(body))
+	})
+
+	t.Run("user made a pay-in and some got distributed to contributors", func(t *testing.T) {
+		setup()
+		defer teardown()
+
+		userDetail := insertTestUser(t, "hello@flatfeestack.io")
+		insertPayInEvent(t, uuid.New(), userDetail.Id, db.PayInSuccess, "USD", 12, 2, 2)
+		repoId, err := db.SetupRepo("github.com/hello-world")
+		require.Nil(t, err)
+
+		err = db.InsertContribution(userDetail.Id, userDetail.Id, *repoId, big.NewInt(3370000), "USD", time.Now(), time.Now())
+		require.Nil(t, err)
+
+		request, _ := http.NewRequest(http.MethodPost, "/users/me/balance", nil)
+		response := httptest.NewRecorder()
+
+		UserBalance(response, request, userDetail)
+
+		assert.Equal(t, 200, response.Code)
+
+		body, _ := io.ReadAll(response.Body)
+		assert.Equal(t, "[{\"currency\":\"USD\",\"balance\":-3369988}]\n", string(body))
+	})
+
+	t.Run("user made a pay-in and has future contribution", func(t *testing.T) {
+		setup()
+		defer teardown()
+
+		userDetail := insertTestUser(t, "hello@flatfeestack.io")
+		insertPayInEvent(t, uuid.New(), userDetail.Id, db.PayInSuccess, "USD", 12, 2, 2)
+		repoId, err := db.SetupRepo("github.com/hello-world")
+		require.Nil(t, err)
+
+		err = db.InsertFutureContribution(userDetail.Id, *repoId, big.NewInt(12), "USD", time.Now(), time.Now())
+		require.Nil(t, err)
+
+		request, _ := http.NewRequest(http.MethodPost, "/users/me/balance", nil)
+		response := httptest.NewRecorder()
+
+		UserBalance(response, request, userDetail)
+
+		assert.Equal(t, 200, response.Code)
+
+		body, _ := io.ReadAll(response.Body)
+		assert.Equal(t, "[{\"currency\":\"USD\",\"balance\":0}]\n", string(body))
+	})
+
+	t.Run("user made a pay-in, has future contribution and distributed funds", func(t *testing.T) {
+		setup()
+		defer teardown()
+
+		userDetail := insertTestUser(t, "hello@flatfeestack.io")
+		insertPayInEvent(t, uuid.New(), userDetail.Id, db.PayInSuccess, "USD", 400, 2, 2)
+		repoId, err := db.SetupRepo("github.com/hello-world")
+		require.Nil(t, err)
+
+		err = db.InsertFutureContribution(userDetail.Id, *repoId, big.NewInt(100), "USD", time.Now(), time.Now())
+		require.Nil(t, err)
+
+		err = db.InsertContribution(userDetail.Id, userDetail.Id, *repoId, big.NewInt(200), "USD", time.Now(), time.Now())
+		require.Nil(t, err)
+
+		request, _ := http.NewRequest(http.MethodPost, "/users/me/balance", nil)
+		response := httptest.NewRecorder()
+
+		UserBalance(response, request, userDetail)
+
+		assert.Equal(t, 200, response.Code)
+
+		body, _ := io.ReadAll(response.Body)
+		assert.Equal(t, "[{\"currency\":\"USD\",\"balance\":100}]\n", string(body))
+	})
+}

--- a/backend/calc_test.go
+++ b/backend/calc_test.go
@@ -497,7 +497,7 @@ func setupUsers(t *testing.T, userNames ...string) []*uuid.UUID {
 func setupRepos(t *testing.T, repoNames ...string) []*uuid.UUID {
 	var repos []*uuid.UUID
 	for _, v := range repoNames {
-		userId1, err := setupRepo(v)
+		userId1, err := db.SetupRepo(v)
 		assert.Nil(t, err)
 		repos = append(repos, userId1)
 	}
@@ -541,21 +541,4 @@ func setupUser(email string) (*uuid.UUID, error) {
 		return nil, err
 	}
 	return &u.Id, nil
-}
-
-func setupRepo(url string) (*uuid.UUID, error) {
-	r := db.Repo{
-		Id:          uuid.New(),
-		Url:         utils.StringPointer(url),
-		GitUrl:      utils.StringPointer(url),
-		Source:      utils.StringPointer("github"),
-		Name:        utils.StringPointer("name"),
-		Description: utils.StringPointer("desc"),
-		CreatedAt:   time.Time{},
-	}
-	err := db.InsertOrUpdateRepo(&r)
-	if err != nil {
-		return nil, err
-	}
-	return &r.Id, nil
 }

--- a/backend/db/test_helpers.go
+++ b/backend/db/test_helpers.go
@@ -1,0 +1,24 @@
+package db
+
+import (
+	"backend/utils"
+	"github.com/google/uuid"
+	"time"
+)
+
+func SetupRepo(url string) (*uuid.UUID, error) {
+	r := Repo{
+		Id:          uuid.New(),
+		Url:         utils.StringPointer(url),
+		GitUrl:      utils.StringPointer(url),
+		Source:      utils.StringPointer("github"),
+		Name:        utils.StringPointer("name"),
+		Description: utils.StringPointer("desc"),
+		CreatedAt:   time.Time{},
+	}
+	err := InsertOrUpdateRepo(&r)
+	if err != nil {
+		return nil, err
+	}
+	return &r.Id, nil
+}


### PR DESCRIPTION
This PR adds a couple of tests regarding the payment-related endpoints. They are not complete so far, but should cover what we manually tested this morning.