### PR TITLE
Add discussion url to proposal description

### DIFF
--- a/forum/api/forum-types.gen.go
+++ b/forum/api/forum-types.gen.go
@@ -75,6 +75,12 @@ type Unauthorized struct {
 	Error string `json:"error"`
 }
 
+// GetPostsParams defines parameters for GetPosts.
+type GetPostsParams struct {
+	// Open Only retrieve open or closed discussions
+	Open *bool `form:"open,omitempty" json:"open,omitempty"`
+}
+
 // PostPostsJSONRequestBody defines body for PostPosts for application/json ContentType.
 type PostPostsJSONRequestBody = PostInput
 

--- a/forum/api/forum.go
+++ b/forum/api/forum.go
@@ -26,7 +26,7 @@ func (s *StrictServerImpl) GetMetrics(ctx context.Context, request GetMetricsReq
 }
 
 func (s *StrictServerImpl) GetPosts(ctx context.Context, request GetPostsRequestObject) (GetPostsResponseObject, error) {
-	posts, err := database.GetAllPosts()
+	posts, err := database.GetAllPosts(request.Params.Open)
 	if err != nil {
 		log.Error(err)
 		return GetPosts500Response{}, nil

--- a/forum/api/forum.yaml
+++ b/forum/api/forum.yaml
@@ -41,6 +41,12 @@ paths:
           $ref: "#/components/responses/InternalServerError"
     get:
       summary: Get all posts
+      parameters:
+        - in: query
+          name: open
+          schema:
+            type: boolean
+          description: Only retrieve open or closed discussions
       responses:
         '200':
           description: OK

--- a/forum/db/post.go
+++ b/forum/db/post.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"database/sql"
 	"fmt"
 	"forum/globals"
 	"github.com/google/uuid"
@@ -23,9 +24,18 @@ type DbPost struct {
 	UpdatedAt *time.Time
 }
 
-func GetAllPosts() ([]DbPost, error) {
+func GetAllPosts(open *bool) ([]DbPost, error) {
 	var posts []DbPost
-	rows, err := globals.DB.Query(`SELECT id, author, content, created_at, "open" ,title, updated_at FROM post`)
+	var rows *sql.Rows
+	var err error
+
+	query := `SELECT id, author, content, created_at, "open" ,title, updated_at FROM post`
+
+	if open != nil {
+		rows, err = globals.DB.Query(query+" WHERE open = $1", open)
+	} else {
+		rows, err = globals.DB.Query(query)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/frontend/src/ts/api.ts
+++ b/frontend/src/ts/api.ts
@@ -274,7 +274,15 @@ export const API = {
     payoutConfig: () => payout.get(`config/payout`).json<PayoutConfig>(),
   },
   forum: {
-    getAllPosts: () => forum.get(`posts`).json<Post[]>(),
+    getAllPosts: (open?: boolean) => {
+      let url = `posts`;
+
+      if (open) {
+        url = `${url}?open=${open}`;
+      }
+
+      return forum.get(url).json<Post[]>();
+    },
     createPost: (postInput: PostInput) =>
       forumToken.post(`posts`, { json: postInput }).json<Post>(),
     getPost: (postId: PostId) => forum.get(`posts/${postId}`).json<Post>(),


### PR DESCRIPTION
This PR allows users to choose a discussion when creating a proposal. The link to the discussion will be added to the proposal description.

Right now, all users can choose to link an open discussion. This could later be refined  to only allow users to link their own discussion. The same discussion can be linked to multiple proposals, also something that could be revised.