### PR TITLE
Switch to Debian for analyzer

### DIFF
--- a/analyzer/Dockerfile
+++ b/analyzer/Dockerfile
@@ -1,19 +1,39 @@
-FROM golang:1.20-alpine3.17 AS builder
-RUN apk add --update --no-cache git cmake make gcc musl-dev openssl-dev
+FROM golang:1.20-bullseye AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt update && \
+    apt install -y --no-install-recommends ca-certificates cmake gcc git g++ libssh2-1-dev libssl-dev make pkg-config && \
+    apt clean
+
 WORKDIR /app
-RUN git clone https://github.com/libgit2/libgit2.git
-RUN cd /app/libgit2 && git checkout v1.5.0 && mkdir build && cd build && cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_TESTS=false && cmake --build . --target install -j 8
+RUN git clone https://github.com/libgit2/libgit2.git && \
+    cd /app/libgit2 && git checkout v1.5.0 && \
+    mkdir build && \
+    cd build && \
+    cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_TESTS=false && \
+    cmake --build . --target install -j $(nproc)
+
 COPY go.* ./
 RUN go mod download
+
 COPY *.go ./
 RUN go build
 
-FROM alpine:3.18
-RUN addgroup -S nonroot && adduser -S nonroot -G nonroot
+FROM debian:bullseye
+
 WORKDIR /app
+
+RUN apt update && \
+    apt install -y --no-install-recommends ca-certificates && \
+    apt clean
+
 COPY banner.txt .
+
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libgit2* /usr/lib/x86_64-linux-gnu/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/pkgconfig/libgit2.pc /usr/lib/x86_64-linux-gnu/pkgconfig/libgit2.pc
+COPY --from=builder /usr/include/git2 /usr/include/git2/
+
 COPY --from=builder /app/analyzer .
-COPY --from=builder /usr/lib/libgit* /usr/lib/
-#USER nonroot
-#https://stackoverflow.com/questions/19331497/set-environment-variables-from-file-of-key-value-pairs/30969768#30969768
+
 ENTRYPOINT ["/app/analyzer"]

--- a/analyzer/analysis.go
+++ b/analyzer/analysis.go
@@ -313,6 +313,9 @@ func cloneOrUpdate(gitUrl string) (*git.Repository, error) {
 
 	//directory already existing,
 	if err != nil {
+		// still log the error, could be the issue is something else than "directory does already exist"
+		log.Errorln(err)
+
 		repo, err = git.OpenRepository(p)
 		if err != nil {
 			return nil, err

--- a/analyzer/api.go
+++ b/analyzer/api.go
@@ -7,7 +7,6 @@ import (
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 	"net/http"
-	"os"
 	"time"
 )
 
@@ -88,11 +87,11 @@ func makeHttpStatusErr(w http.ResponseWriter, errString string, httpStatusError 
 
 func callbackToWebhook(body AnalysisCallback, url string) {
 	if body.Error == "" {
-		log.Printf("About to returt the following data: %v", body.Result)
+		log.Printf("About to return the following data: %v", body.Result)
 	}
 
 	reqBody, _ := json.Marshal(body)
-	log.Printf("Call to %s with success %v", os.Getenv("WEBHOOK_CALLBACK_URL"), body.Error == "")
+	log.Printf("Call to %s with success %v", opts.BackendCallbackUrl, body.Error == "")
 
 	c := &http.Client{
 		Timeout: 15 * time.Second,


### PR DESCRIPTION
We saw a strange issue on Production where libgit2 was unable to find a freshly cloned repository on the file system.

This PR switches the base image for the analyzer from Alpine to Debian, as recommended by @gsmachado, which resolves the issue.