### PR TITLE
fix email validation with added required pattern

### DIFF
--- a/frontend/src/routes/ConfirmForgot.svelte
+++ b/frontend/src/routes/ConfirmForgot.svelte
@@ -2,6 +2,7 @@
   import Dots from "../components/Dots.svelte";
   import { confirmReset } from "../ts/services";
   import { navigate, link } from "svelte-routing";
+  import { emailValidationPattern } from "../ts/utils";
 
   export let email: string;
   export let token: string;
@@ -70,6 +71,7 @@
         maxlength="100"
         type="email"
         id="email"
+        pattern={emailValidationPattern}
         name="email"
         bind:value={email}
         class="rounded py-2 border-primary-900"

--- a/frontend/src/routes/ConfirmInvite.svelte
+++ b/frontend/src/routes/ConfirmInvite.svelte
@@ -2,7 +2,7 @@
   import Dots from "../components/Dots.svelte";
   import { confirmInvite } from "../ts/services";
   import { navigate, link } from "svelte-routing";
-
+  import { emailValidationPattern } from "../ts/utils";
   export let email: string;
   export let emailToken: string;
   export let inviteByEmail: string;
@@ -72,6 +72,7 @@
         maxlength="100"
         type="email"
         id="email"
+        pattern={emailValidationPattern}
         name="email"
         bind:value={email}
         class="rounded py-2 border-primary-900"

--- a/frontend/src/routes/Forgot.svelte
+++ b/frontend/src/routes/Forgot.svelte
@@ -2,7 +2,7 @@
   import { link } from "svelte-routing";
   import { API } from "./../ts/api";
   import Dots from "../components/Dots.svelte";
-
+  import { emailValidationPattern } from "../ts/utils";
   let email = "";
   let error = "";
   let isSubmitting = false;
@@ -70,6 +70,7 @@
           size="100"
           maxlength="100"
           type="email"
+          pattern={emailValidationPattern}
           id="email"
           name="email"
           bind:value={email}

--- a/frontend/src/routes/Invitations.svelte
+++ b/frontend/src/routes/Invitations.svelte
@@ -13,6 +13,7 @@
   } from "@fortawesome/free-solid-svg-icons";
   import { formatDate, timeSince } from "../ts/services";
   import Dots from "../components/Dots.svelte";
+  import { emailValidationPattern } from "../ts/utils";
 
   let invites: Invitation[] = [];
   let inviteEmail: string;
@@ -147,6 +148,7 @@
                 size="24"
                 maxlength="50"
                 type="email"
+                pattern={emailValidationPattern}
                 required
                 bind:value={inviteEmail}
               />&nbsp;

--- a/frontend/src/routes/Login.svelte
+++ b/frontend/src/routes/Login.svelte
@@ -2,6 +2,7 @@
   import { login } from "../ts/services";
   import Dots from "../components/Dots.svelte";
   import { navigate, link } from "svelte-routing";
+  import { emailValidationPattern } from "../ts/utils";
 
   let email = "";
   let password = "";
@@ -70,6 +71,7 @@
         maxlength="100"
         type="email"
         id="email"
+        pattern={emailValidationPattern}
         name="email"
         bind:value={email}
       />

--- a/frontend/src/routes/Settings.svelte
+++ b/frontend/src/routes/Settings.svelte
@@ -11,6 +11,7 @@
   import { error, user } from "../ts/mainStore";
   import { formatDate, timeSince } from "../ts/services";
   import type { GitUser } from "../types/backend";
+  import { emailValidationPattern } from "../ts/utils";
 
   let fileInput;
   let username: undefined | string;
@@ -195,6 +196,7 @@
                   id="email-input"
                   name="email"
                   type="email"
+                  pattern={emailValidationPattern}
                   required
                   bind:value={newEmail}
                   placeholder="Email"

--- a/frontend/src/routes/Signup.svelte
+++ b/frontend/src/routes/Signup.svelte
@@ -3,6 +3,7 @@
   import { API } from "./../ts/api";
   import Dots from "../components/Dots.svelte";
   import { removeToken } from "../ts/services";
+  import { emailValidationPattern } from "../ts/utils";
 
   let email = "";
   let password = "";
@@ -72,6 +73,7 @@
           size="100"
           maxlength="100"
           type="email"
+          pattern={emailValidationPattern}
           id="email"
           name="email"
           bind:value={email}

--- a/frontend/src/ts/utils.ts
+++ b/frontend/src/ts/utils.ts
@@ -1,3 +1,5 @@
+export const emailValidationPattern = "[a-z0-9._%+-]+@[a-z0-9.-]+.[a-z]{2,}$";
+
 export const getColor1 = function (input: string) {
   return (
     "hsl(" +


### PR DESCRIPTION
previously foo@bar was a valid option as an email address which should not be the case. This pattern prevents this.