### PR TITLE
Improve deployment setup

### DIFF
--- a/.github/workflows/build-and-deploy-test.yaml
+++ b/.github/workflows/build-and-deploy-test.yaml
@@ -359,15 +359,20 @@ jobs:
           key: ${{ secrets.DEPLOY_MACMINI_PRIVATE_KEY }}
           known_hosts: ${{ secrets.DEPLOY_MACMINI_KNOWN_HOST }}
 
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - name: Login to DigitalOcean container registry
+        run: doctl registry login --expiry-seconds 10000
+
       - name: Deploy - TEST
         run: |
-          scp -P 3000 deploy/docker-compose.yml sibex@axelra.net:/Users/sibex/flatfeestack
-          rsync -avzm -e 'ssh -p 3000' --include='*/' --include='.env' --exclude='*' . sibex@axelra.net:/Users/sibex/flatfeestack
-          ssh -p 3000 axelra.net -l sibex "doctl auth init --access-token ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}"
-          ssh -p 3000 axelra.net -l sibex "doctl registry login --access-token ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}"
-          ssh -p 3000 axelra.net -l sibex "cd flatfeestack && TAG_IMAGE=$TAG_IMAGE BASE_PATH=/Users/sibex/flatfeestack docker compose up --pull always -d --no-build"
-          ssh -p 3000 axelra.net -l sibex "rm -r /Users/sibex/flatfeestack/*"
-          ssh -p 3000 axelra.net -l sibex "docker system prune -af"
+          docker context create test --docker "host=ssh://sibex@axelra.net:3000"
+          docker --context test compose -p "flatfeestack" -f deploy/docker-compose.yml up -d --remove-orphans --pull always
+          docker --context test system prune -af
+          docker --context test ps
         env:
           TEST_ADMINS: "tom.test@bocek.ch;tom.t1@bocek.ch;tom.t2@bocek.ch;guil@axlabs.com;gsm@machados.org"
           TEST_ANALYZER_PASSWORD: ${{ secrets.TEST_ANALYZER_PASSWORD }}

--- a/.github/workflows/build-and-deploy-test.yaml
+++ b/.github/workflows/build-and-deploy-test.yaml
@@ -353,71 +353,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Create .env files
-        run: |
-          cp analyzer/.example.env analyzer/.env
-          cp backend/.example.env backend/.env
-          cp forum/.example.env forum/.env
-          cp fastauth/.example.env fastauth/.env
-          cp payout/.example.env payout/.env
-          cp db/.example.env db/.env
-
-      - name: Edit backend .env file
-        run: |
-          sed -i 's#%%EMAIL_TOKEN%%#${{ secrets.TEST_EMAIL_TOKEN }}#g' backend/.env
-          sed -i 's#EMAIL_PREFIX=http://localhost:8080#EMAIL_PREFIX=https://test.flatfeestack.io#g' backend/.env
-          sed -i 's#%%STRIPE_SECRET_API%%#${{ secrets.TEST_STRIPE_SECRET_API }}#g' backend/.env
-          sed -i 's#%%STRIPE_PUBLIC_API%%#${{ secrets.TEST_STRIPE_PUBLIC_API }}#g' backend/.env
-          sed -i 's#%%STRIPE_SECRET_WEBHOOK%%#${{ secrets.TEST_STRIPE_SECRET_WEBHOOK }}#g' backend/.env
-          sed -i 's#%%NOWPAYMENTS_TOKEN%%#${{ secrets.TEST_NOWPAYMENTS_TOKEN }}#g' backend/.env
-          sed -i 's#%%NOWPAYMENTS_IPN_KEY%%#${{ secrets.TEST_NOWPAYMENTS_IPN_KEY }}#g' backend/.env
-          sed -i 's#ENV=local#ENV=dev#g' backend/.env
-          sed -i 's#ADMINS=jonas@flatfeestack.io#ADMINS=tom.test@bocek.ch;tom.t1@bocek.ch;tom.t2@bocek.ch;guil@axlabs.com;gsm@machados.org#g' backend/.env
-          sed -i 's#ANALYZER_USERNAME=flatfeestack#ANALYZER_USERNAME=${{ secrets.TEST_ANALYZER_USERNAME }}#g' backend/.env
-          sed -i 's#ANALYZER_PASSWORD=analyzer#ANALYZER_PASSWORD=${{ secrets.TEST_ANALYZER_PASSWORD }}#g' backend/.env
-          sed -i 's#BACKEND_USERNAME=flatfeestack#BACKEND_USERNAME=${{ secrets.TEST_BACKEND_USERNAME }}#g' backend/.env
-          sed -i 's#BACKEND_PASSWORD=backend#BACKEND_PASSWORD=${{ secrets.TEST_BACKEND_PASSWORD }}#g' backend/.env
-          sed -i 's#PAYOUT_USERNAME=flatfeestack#PAYOUT_USERNAME=${{ secrets.TEST_PAYOUT_USERNAME }}#g' backend/.env
-          sed -i 's#PAYOUT_PASSWORD=payout#PAYOUT_PASSWORD=${{ secrets.TEST_PAYOUT_PASSWORD }}#g' backend/.env
-
-      - name: Edit fastauth .env file
-        run: |
-          sed -i 's#%%EMAIL_TOKEN%%#${{ secrets.TEST_EMAIL_TOKEN }}#g' fastauth/.env
-          sed -i 's#EMAIL_PREFIX=http://localhost:8080#EMAIL_PREFIX=https://test.flatfeestack.io#g' fastauth/.env
-          sed -i 's#ENV=local#ENV=dev#g' fastauth/.env
-
-      - name: Edit payout .env file
-        run: |
-          sed -i 's#ETH_URL=http://ganache:8545#ETH_URL=https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161#g' payout/.env
-          sed -i 's#ETH_PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80#ETH_PRIVATE_KEY=${{ secrets.TEST_ETH_PRIVATE_KEY }}#g' payout/.env
-          sed -i 's#ETH_CONTRACT=0x95401dc811bb5740090279Ba06cfA8fcF6113778#ETH_CONTRACT=0x194bbC28bA0C0105149ddEEE0800d81Cac307612#g' payout/.env
-          sed -i 's#NEO_URL=http://host.docker.internal:50012#NEO_URL=http://seed1t4.neo.org:20332#g' payout/.env
-          sed -i 's#USDC_URL=http://ganache:8545#USDC_URL=https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161#g' payout/.env
-          sed -i 's#USDC_PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80#USDC_PRIVATE_KEY=${{ secrets.TEST_USDC_PRIVATE_KEY }}#g' payout/.env
-          sed -i 's#USDC_CONTRACT=0x95401dc811bb5740090279Ba06cfA8fcF6113778#USDC_CONTRACT=0xf25f565A8c03d9401BEc46B61EACf89ce8F524D5#g' payout/.env
-          sed -i 's#DAO_WALLET_CONTRACT=0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0#DAO_WALLET_CONTRACT=0xa10825Dc5C0A6bF05EbDB586cAf52BdB777BAe5a#g' payout/.env
-          sed -i 's#DAO_MEMBERSHIP_CONTRACT=0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9#DAO_MEMBERSHIP_CONTRACT=0xA1c3770345287aF14f63098a3Fb044860474A2F3#g' payout/.env
-          sed -i 's#DAO_DAO_CONTRACT=0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e#DAO_DAO_CONTRACT=0x82293E85698C606E2fF88904873fD11a30263355#g' payout/.env
-          sed -i 's#ENV=local#ENV=dev#g' payout/.env
-          sed -i 's#PAYOUT_USERNAME=flatfeestack#PAYOUT_USERNAME=${{ secrets.TEST_PAYOUT_USERNAME }}#g' payout/.env
-          sed -i 's#PAYOUT_PASSWORD=payout#PAYOUT_PASSWORD=${{ secrets.TEST_PAYOUT_PASSWORD }}#g' payout/.env
-
-      - name: Edit forum .env file
-        run: |
-          sed -i 's#BACKEND_USERNAME=flatfeestack#BACKEND_USERNAME=${{ secrets.TEST_BACKEND_USERNAME }}#g' forum/.env
-          sed -i 's#BACKEND_PASSWORD=backend#BACKEND_PASSWORD=${{ secrets.TEST_BACKEND_PASSWORD }}#g' forum/.env
-          sed -i 's#DAO_CONTRACT_ADDRESS=0x87E3D01B36b07794AB2c2B72C6FD958Fc98cCab3#DAO_CONTRACT_ADDRESS=0x82293E85698C606E2fF88904873fD11a30263355#g' forum/.env
-          sed -i 's#ENV=local#ENV=dev#g' forum/.env
-          sed -i 's#ETH_WS_URL=ws://ganache:8545#ETH_WS_URL=wss://goerli.infura.io/ws/v3/9aa3d95b3bc440fa88ea12eaa4456161#g' forum/.env
-
-      - name: Edit analyzer .env file
-        run: |
-          sed -i 's#ANALYZER_USERNAME=flatfeestack#ANALYZER_USERNAME=${{ secrets.TEST_ANALYZER_USERNAME }}#g' analyzer/.env
-          sed -i 's#ANALYZER_PASSWORD=analyzer#ANALYZER_PASSWORD=${{ secrets.TEST_ANALYZER_PASSWORD }}#g' analyzer/.env
-          sed -i 's#BACKEND_USERNAME=flatfeestack#BACKEND_USERNAME=${{ secrets.TEST_BACKEND_USERNAME }}#g' analyzer/.env
-          sed -i 's#BACKEND_PASSWORD=backend#BACKEND_PASSWORD=${{ secrets.TEST_BACKEND_PASSWORD }}#g' analyzer/.env
-          sed -i 's#ENV=local#ENV=dev#g' analyzer/.env
-
       - name: Install SSH key
         uses: shimataro/ssh-key-action@v2
         with:
@@ -433,3 +368,20 @@ jobs:
           ssh -p 3000 axelra.net -l sibex "cd flatfeestack && TAG_IMAGE=$TAG_IMAGE BASE_PATH=/Users/sibex/flatfeestack docker compose up --pull always -d --no-build"
           ssh -p 3000 axelra.net -l sibex "rm -r /Users/sibex/flatfeestack/*"
           ssh -p 3000 axelra.net -l sibex "docker system prune -af"
+        env:
+          TEST_ADMINS: "tom.test@bocek.ch;tom.t1@bocek.ch;tom.t2@bocek.ch;guil@axlabs.com;gsm@machados.org"
+          TEST_ANALYZER_PASSWORD: ${{ secrets.TEST_ANALYZER_PASSWORD }}
+          TEST_ANALYZER_USERNAME: ${{ secrets.TEST_ANALYZER_USERNAME }}
+          TEST_BACKEND_PASSWORD: ${{ secrets.TEST_BACKEND_PASSWORD }}
+          TEST_BACKEND_USERNAME: ${{ secrets.TEST_BACKEND_USERNAME }}
+          TEST_DAO_CONTRACT_ADDRESS: "0x82293E85698C606E2fF88904873fD11a30263355"
+          TEST_EMAIL_TOKEN: ${{ secrets.TEST_EMAIL_TOKEN }}
+          TEST_ETH_PRIVATE_KEY: ${{ secrets.TEST_ETH_PRIVATE_KEY }}
+          TEST_ETH_URL: ${{ secrets.TEST_ETH_URL }}
+          TEST_ETH_WS_URL: ${{ secrets.TEST_ETH_WS_URL }}
+          TEST_PAYOUT_PASSWORD: ${{ secrets.TEST_PAYOUT_PASSWORD }}
+          TEST_PAYOUT_USERNAME: ${{ secrets.TEST_PAYOUT_USERNAME }}
+          TEST_STRIPE_PUBLIC_API: ${{ secrets.TEST_STRIPE_PUBLIC_API }}
+          TEST_STRIPE_SECRET_API: ${{ secrets.TEST_STRIPE_SECRET_API }}
+          TEST_STRIPE_SECRET_WEBHOOK: ${{ secrets.TEST_STRIPE_SECRET_WEBHOOK }}
+          TEST_USDC_PRIVATE_KEY: ${{ secrets.TEST_USDC_PRIVATE_KEY }}

--- a/.github/workflows/build-and-deploy-test.yaml
+++ b/.github/workflows/build-and-deploy-test.yaml
@@ -370,7 +370,7 @@ jobs:
       - name: Deploy - TEST
         run: |
           docker context create test --docker "host=ssh://sibex@axelra.net:3000"
-          docker --context test compose -p "flatfeestack" -f deploy/docker-compose.yml up -d --remove-orphans --pull always
+          docker --context test compose -p "flatfeestack" -f deploy/docker-compose.yml up -d --remove-orphans --pull always --wait
           docker --context test system prune -af
           docker --context test ps
         env:

--- a/analyzer/Dockerfile
+++ b/analyzer/Dockerfile
@@ -29,12 +29,15 @@ ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/opt/libgit2/lib"
 WORKDIR /app
 
 RUN apt update && \
-    apt install -y --no-install-recommends ca-certificates && \
+    apt install -y --no-install-recommends ca-certificates curl && \
     apt clean
 
 COPY banner.txt .
 
 COPY --from=builder /opt/libgit2 /opt/libgit2/
 COPY --from=builder /app/analyzer .
+
+HEALTHCHECK --interval=30s --timeout=3s \
+  CMD curl -f http://localhost:${PORT}/metrics || exit 1
 
 ENTRYPOINT ["/app/analyzer"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -14,10 +14,20 @@ COPY *.go *.sql banner.txt ./
 RUN go build
 
 FROM alpine:3.18
-RUN addgroup -S nonroot -g 31323 && adduser -S nonroot -G nonroot -u 31323
+
 WORKDIR /app
+
+RUN addgroup -S nonroot -g 31323 && adduser -S nonroot -G nonroot -u 31323
+RUN apk add --update --no-cache curl
+
 COPY --from=builder /app/banner.txt /app/backend /app/db/init.sql ./
 COPY --from=builder /app/db/init.sql ./db/
+
 COPY mail-templates ./mail-templates/
+
 USER nonroot
+
+HEALTHCHECK --interval=30s --timeout=3s \
+  CMD curl -f http://localhost:${PORT}/metrics || exit 1
+
 ENTRYPOINT ["/app/backend"]

--- a/caddy/Dockerfile
+++ b/caddy/Dockerfile
@@ -1,2 +1,8 @@
 FROM caddy:2-alpine
+
+RUN apk add --update --no-cache curl
+
 COPY ./Caddyfile /etc/caddy/Caddyfile
+
+HEALTHCHECK --interval=30s --timeout=3s \
+  CMD curl -f http://localhost:8080 || exit 1

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       DB_DRIVER: postgres
       DB_PATH: postgresql://postgres:password@db:5432/flatfeestack?sslmode=disable
       DB_SCRIPTS: init.sql
-      DETAILS: "true"
+      DETAILS: 'true'
       DEV: staging
       EMAIL_FROM: info@flatfeestack.io
       EMAIL_FROM_NAME: Flatfeestack
@@ -19,8 +19,8 @@ services:
       ENV: local
       HS256: test-seed
       PORT: 9081
-      PWFLOW: "true"
-      USER_ENDPOINTS: "true"
+      PWFLOW: 'true'
+      USER_ENDPOINTS: 'true'
     depends_on:
       db:
         condition: service_healthy
@@ -90,7 +90,7 @@ services:
       BACKEND_USERNAME: ${TEST_BACKEND_USERNAME}
       ENV: staging
       PORT: 9083
-    volumes: ['${BASE_PATH:-.}/.repos:/tmp/repos']
+    volumes: [/Users/sibex/flatfeestack/.repos:/tmp/repos]
   payout:
     image: registry.digitalocean.com/flatfeestack/payout:${TAG_IMAGE:-latest}
     restart: always
@@ -116,7 +116,7 @@ services:
     image: registry.digitalocean.com/flatfeestack/frontend:${TAG_IMAGE:-latest}
   db:
     image: postgres:15-alpine
-    volumes: ['${BASE_PATH:-.}/.db:/var/lib/postgresql/data:z']
+    volumes: [/Users/sibex/flatfeestack/.db:/var/lib/postgresql/data:z]
     environment:
       POSTGRES_DB: flatfeestack
       POSTGRES_PASSWORD: password

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,67 +1,133 @@
-version: "3.9"
-
+---
+version: '3.9'
 services:
   auth:
     image: registry.digitalocean.com/flatfeestack/fastauth:${TAG_IMAGE:-latest}
     restart: always
-    env_file:
-      - ${BASE_PATH:-.}/fastauth/.env
+    environment:
+      ADMINS: ${TEST_ADMINS}
+      DB_DRIVER: postgres
+      DB_PATH: postgresql://postgres:password@db:5432/flatfeestack?sslmode=disable
+      DB_SCRIPTS: init.sql
+      DETAILS: "true"
+      DEV: staging
+      EMAIL_FROM: info@flatfeestack.io
+      EMAIL_FROM_NAME: Flatfeestack
+      EMAIL_PREFIX: https://test.flatfeestack.io
+      EMAIL_TOKEN: ${TEST_EMAIL_TOKEN}
+      EMAIL_URL: https://api.sendgrid.com/v3/mail/send
+      ENV: local
+      HS256: test-seed
+      PORT: 9081
+      PWFLOW: "true"
+      USER_ENDPOINTS: "true"
     depends_on:
       db:
         condition: service_healthy
-
   backend:
     image: registry.digitalocean.com/flatfeestack/backend:${TAG_IMAGE:-latest}
     restart: always
-    env_file:
-      - ${BASE_PATH:-.}/backend/.env
+    environment:
+      ADMINS: ${TEST_ADMINS}
+      ANALYZER_PASSWORD: ${TEST_ANALYZER_PASSWORD}
+      ANALYZER_URL: http://analyzer:9083
+      ANALYZER_USERNAME: ${TEST_ANALYZER_USERNAME}
+      BACKEND_PASSWORD: ${TEST_BACKEND_PASSWORD}
+      BACKEND_USERNAME: ${TEST_BACKEND_USERNAME}
+      DB_DRIVER: postgres
+      DB_PATH: postgresql://postgres:password@db:5432/flatfeestack?sslmode=disable
+      DB_SCRIPTS: init.sql
+      EMAIL_FROM: info@flatfeestack.io
+      EMAIL_FROM_NAME: Flatfeestack
+      EMAIL_PREFIX: https://test.flatfeestack.io
+      EMAIL_TOKEN: ${TEST_EMAIL_TOKEN}
+      EMAIL_URL: https://api.sendgrid.com/v3/mail/send
+      ENV: staging
+      HS256: test-seed
+      NOWPAYMENTS_API_URL: https://api.nowpayments.io/v1/
+      NOWPAYMENTS_IPN_CALLBACK_URL: https://test.flatfeestack.io/hooks/nowpayments
+      NOWPAYMENTS_IPN_KEY: '%%NOWPAYMENTS_IPN_KEY%%'
+      NOWPAYMENTS_TOKEN: '%%NOWPAYMENTS_TOKEN%%'
+      PAYOUT_PASSWORD: ${TEST_PAYOUT_PASSWORD}
+      PAYOUT_URL: http://payout:9084
+      PAYOUT_USERNAME: ${TEST_PAYOUT_USERNAME}
+      PORT: 9082
+      STRIPE_PUBLIC_API: ${TEST_STRIPE_PUBLIC_API}
+      STRIPE_SECRET_API: ${TEST_STRIPE_SECRET_API}
+      STRIPE_SECRET_WEBHOOK: ${TEST_STRIPE_SECRET_WEBHOOK}
     depends_on:
       db:
         condition: service_healthy
-
   forum:
     image: registry.digitalocean.com/flatfeestack/forum:${TAG_IMAGE:-latest}
     restart: always
-    env_file:
-      - ${BASE_PATH:-.}/forum/.env
+    environment:
+      ADMINS: ${TEST_ADMINS}
+      BACKEND_PASSWORD: backend
+      BACKEND_URL: http://backend:9082/
+      BACKEND_USERNAME: flatfeestack
+      DAO_CONTRACT_ADDRESS: ${TEST_DAO_CONTRACT_ADDRESS}
+      DB_DRIVER: postgres
+      DB_PATH: postgresql://postgres:password@db:5432/flatfeestack?sslmode=disable
+      DB_SCRIPTS: init.sql
+      ENV: staging
+      ETH_WS_URL: ${TEST_ETH_WS_URL}
+      HS256: test-seed
+      PORT: 9086
     depends_on:
       db:
         condition: service_healthy
       backend:
         condition: service_started
-
   analyzer:
     image: registry.digitalocean.com/flatfeestack/analyzer:${TAG_IMAGE:-latest}
     restart: always
-    env_file:
-      - ${BASE_PATH:-.}/analyzer/.env
-    volumes:
-      - ${BASE_PATH:-.}/.repos:/tmp/repos
-
+    environment:
+      ANALYZER_PASSWORD: ${TEST_ANALYZER_PASSWORD}
+      ANALYZER_USERNAME: ${TEST_ANALYZER_USERNAME}
+      BACKEND_CALLBACK_URL: http://backend:9082/hooks/analyzer
+      BACKEND_PASSWORD: ${TEST_BACKEND_PASSWORD}
+      BACKEND_USERNAME: ${TEST_BACKEND_USERNAME}
+      ENV: staging
+      PORT: 9083
+    volumes: ['${BASE_PATH:-.}/.repos:/tmp/repos']
   payout:
     image: registry.digitalocean.com/flatfeestack/payout:${TAG_IMAGE:-latest}
     restart: always
-    env_file:
-      - ${BASE_PATH:-.}/payout/.env
-
+    environment:
+      DAO_DAO_CONTRACT: ${TEST_DAO_CONTRACT_ADDRESS}
+      DAO_MEMBERSHIP_CONTRACT: 0xA1C3770345287AF14F63098A3FB044860474A2F3
+      DAO_WALLET_CONTRACT: 0xa10825dc5c0a6bf05ebdb586caf52bdb777bae5a
+      ENV: staging
+      ETH_CONTRACT: 0x194bbc28ba0c0105149ddeee0800d81cac307612
+      ETH_PRIVATE_KEY: ${TEST_ETH_PRIVATE_KEY}
+      ETH_URL: ${TEST_ETH_URL}
+      HS256: test-seed
+      NEO_CONTRACT: Kyw24tcti1qxpVSJfbKwZFFcokWUbBUWZMmtQWRddy1AgtULuTND
+      NEO_PRIVATE_KEY: KzrHihgvHGpF9urkSbrbRcgrxSuVhpDWkSfWvSg97pJ5YgbdHKCQ
+      NEO_URL: http://seed1t4.neo.org:20332
+      PAYOUT_PASSWORD: ${TEST_PAYOUT_PASSWORD}
+      PAYOUT_USERNAME: ${TEST_PAYOUT_USERNAME}
+      USDC_CONTRACT: 0xf25f565a8c03d9401bec46b61eacf89ce8f524d5
+      USDC_PRIVATE_KEY: ${TEST_USDC_PRIVATE_KEY}
+      USDC_URL: ${TEST_ETH_URL}
+      PORT: 9084
   frontend:
     image: registry.digitalocean.com/flatfeestack/frontend:${TAG_IMAGE:-latest}
-
   db:
     image: postgres:15-alpine
-    volumes:
-      - ${BASE_PATH:-.}/.db:/var/lib/postgresql/data:z
-    env_file:
-      - ${BASE_PATH:-.}/db/.env
+    volumes: ['${BASE_PATH:-.}/.db:/var/lib/postgresql/data:z']
+    environment:
+      POSTGRES_DB: flatfeestack
+      POSTGRES_PASSWORD: password
+      POSTGRES_USER: postgres
     restart: always
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready" ]
+      test: [CMD-SHELL, pg_isready]
       interval: 3s
       timeout: 5s
       retries: 30
-
   caddy:
     image: registry.digitalocean.com/flatfeestack/caddy:${TAG_IMAGE:-latest}
     restart: always
-    ports:
-      - "8080:8080"
+    ports: [8080:8080]

--- a/fastauth/Dockerfile
+++ b/fastauth/Dockerfile
@@ -1,15 +1,27 @@
-FROM golang:1.20-alpine AS base
+FROM golang:1.20-alpine AS builder
+
 RUN apk update && apk add --update make gcc musl-dev
+
 WORKDIR /app
+
 COPY go.* ./
+
 RUN go mod download
 
-FROM base as builder
 COPY *.go *.sql login.html banner.txt ./
+
 RUN go build
 
 FROM alpine:3.18
+
 WORKDIR /app
+
+RUN apk add --update --no-cache curl
+
 COPY --from=builder /app/login.html /app/banner.txt /app/fastauth /app/rmdb.sql /app/init.sql ./
 COPY mail-templates ./mail-templates/
+
+HEALTHCHECK --interval=30s --timeout=3s \
+  CMD curl -f http://localhost:${PORT}/metrics || exit 1
+
 ENTRYPOINT ["/app/fastauth"]

--- a/forum/Dockerfile
+++ b/forum/Dockerfile
@@ -16,8 +16,17 @@ COPY *.go banner.txt ./
 RUN go build
 
 FROM alpine:3.18
-RUN addgroup -S nonroot -g 31323 && adduser -S nonroot -G nonroot -u 31323
+
 WORKDIR /app
+
+RUN addgroup -S nonroot -g 31323 && adduser -S nonroot -G nonroot -u 31323
+RUN apk add --update --no-cache curl
+
 COPY --from=builder /app/forum /app/db/init.sql /app/banner.txt ./
+
 USER nonroot
+
+HEALTHCHECK --interval=30s --timeout=3s \
+  CMD curl -f http://localhost:${PORT}/metrics || exit 1
+
 ENTRYPOINT ["/app/forum"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -10,5 +10,11 @@ COPY ./src ./src
 RUN pnpm prod
 
 FROM caddy:2-alpine
+
+RUN apk add --update --no-cache curl
+
 COPY Caddyfile /etc/caddy/Caddyfile
 COPY --from=base /app/dist/client /var/www/html
+
+HEALTHCHECK --interval=30s --timeout=3s \
+  CMD curl -f http://localhost:9085 || exit 1

--- a/payout/Dockerfile
+++ b/payout/Dockerfile
@@ -1,10 +1,12 @@
-FROM golang:1.20-alpine AS base
-RUN apk add --update --no-cache gcc musl-dev
-WORKDIR /app
-COPY go.* ./
-RUN go mod download
+FROM golang:1.20-alpine AS builder
 
-FROM base as builder
+RUN apk add --update --no-cache gcc musl-dev
+
+WORKDIR /app
+
+COPY go.* ./
+
+RUN go mod download
 
 COPY contracts/ ./contracts/
 COPY metrics/ ./metrics/
@@ -13,8 +15,17 @@ COPY *.go banner.txt PayoutNeo.nef PayoutNeo.manifest.json ./
 RUN go build
 
 FROM alpine:3.18
-RUN addgroup -S nonroot -g 31323 && adduser -S nonroot -G nonroot -u 31323
+
 WORKDIR /app
+
+RUN addgroup -S nonroot -g 31323 && adduser -S nonroot -G nonroot -u 31323
+RUN apk add --update --no-cache curl
+
 COPY --from=builder /app/banner.txt /app/PayoutNeo.nef /app/PayoutNeo.manifest.json /app/payout ./
+
 USER nonroot
+
+HEALTHCHECK --interval=30s --timeout=3s \
+  CMD curl -f http://localhost:${PORT}/metrics || exit 1
+
 ENTRYPOINT ["/app/payout"]


### PR DESCRIPTION
- Remove dependency of the staging deployment on the values of the example env files. Instead, all environment variables are passed directly using the separate docker compose file.
- Deploy with `docker context` instead of logging in to the Mac Mini with SSH
- Add health checks to all services and wait on deployment until all containers are marked as healthy