### PR TITLE
Show link between proposal and discussion in frontend

### DIFF
--- a/forum/api/forum.go
+++ b/forum/api/forum.go
@@ -56,13 +56,14 @@ func (s *StrictServerImpl) PostPosts(ctx context.Context, request PostPostsReque
 		return PostPosts500Response{}, nil
 	}
 	return PostPosts201JSONResponse{
-		Author:    newPost.Author,
-		Content:   newPost.Content,
-		CreatedAt: newPost.CreatedAt,
-		Id:        newPost.Id,
-		Open:      newPost.Open,
-		Title:     newPost.Title,
-		UpdatedAt: newPost.UpdatedAt,
+		Author:      newPost.Author,
+		Content:     newPost.Content,
+		CreatedAt:   newPost.CreatedAt,
+		Id:          newPost.Id,
+		Open:        newPost.Open,
+		Title:       newPost.Title,
+		UpdatedAt:   newPost.UpdatedAt,
+		ProposalIds: newPost.ProposalIds,
 	}, nil
 }
 
@@ -88,13 +89,14 @@ func (s *StrictServerImpl) GetPostsPostId(ctx context.Context, request GetPostsP
 		return GetPostsPostId404JSONResponse{NotFoundJSONResponse{Error: fmt.Sprintf("post with id %v does not exist", request.PostId)}}, nil
 	}
 	return GetPostsPostId200JSONResponse{
-		Author:    dbPost.Author,
-		Content:   dbPost.Content,
-		CreatedAt: dbPost.CreatedAt,
-		Id:        dbPost.Id,
-		Open:      dbPost.Open,
-		Title:     dbPost.Title,
-		UpdatedAt: dbPost.UpdatedAt,
+		Author:      dbPost.Author,
+		Content:     dbPost.Content,
+		CreatedAt:   dbPost.CreatedAt,
+		Id:          dbPost.Id,
+		Open:        dbPost.Open,
+		Title:       dbPost.Title,
+		UpdatedAt:   dbPost.UpdatedAt,
+		ProposalIds: dbPost.ProposalIds,
 	}, nil
 }
 
@@ -132,13 +134,14 @@ func (s *StrictServerImpl) PutPostsPostId(ctx context.Context, request PutPostsP
 		return PutPostsPostId500Response{}, nil
 	}
 	return PutPostsPostId200JSONResponse{
-		Id:        updatedPost.Id,
-		Author:    updatedPost.Author,
-		Title:     updatedPost.Title,
-		Content:   updatedPost.Content,
-		CreatedAt: updatedPost.CreatedAt,
-		UpdatedAt: updatedPost.UpdatedAt,
-		Open:      updatedPost.Open,
+		Id:          updatedPost.Id,
+		Author:      updatedPost.Author,
+		Title:       updatedPost.Title,
+		Content:     updatedPost.Content,
+		CreatedAt:   updatedPost.CreatedAt,
+		UpdatedAt:   updatedPost.UpdatedAt,
+		Open:        updatedPost.Open,
+		ProposalIds: updatedPost.ProposalIds,
 	}, nil
 }
 
@@ -280,6 +283,27 @@ func (s *StrictServerImpl) PutPostsPostIdCommentsCommentId(ctx context.Context, 
 		Content:   comment.Content,
 		CreatedAt: comment.CreatedAt,
 		UpdatedAt: comment.UpdatedAt,
+	}, nil
+}
+
+func (s *StrictServerImpl) GetPostsByProposalIdProposalId(ctx context.Context, request GetPostsByProposalIdProposalIdRequestObject) (GetPostsByProposalIdProposalIdResponseObject, error) {
+	dbPost, err := database.GetPostByProposalId(request.ProposalId)
+	if err != nil {
+		log.Error(err)
+		return GetPostsPostId500Response{}, nil
+	}
+	if dbPost == nil {
+		return GetPostsByProposalIdProposalId404JSONResponse{NotFoundJSONResponse{Error: fmt.Sprintf("post with discussion %v does not exist", request.ProposalId)}}, nil
+	}
+	return GetPostsByProposalIdProposalId200JSONResponse{
+		Author:      dbPost.Author,
+		Content:     dbPost.Content,
+		CreatedAt:   dbPost.CreatedAt,
+		Id:          dbPost.Id,
+		Open:        dbPost.Open,
+		Title:       dbPost.Title,
+		UpdatedAt:   dbPost.UpdatedAt,
+		ProposalIds: dbPost.ProposalIds,
 	}, nil
 }
 

--- a/forum/api/forum.yaml
+++ b/forum/api/forum.yaml
@@ -140,6 +140,28 @@ paths:
         '500':
           $ref: "#/components/responses/InternalServerError"
 
+  /posts/byProposalId/{proposalId}:
+    get:
+      summary: Get a specific post by proposal id
+      parameters:
+        - name: proposalId
+          in: path
+          description: ID of the proposal
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Post"
+        '404':
+          $ref: "#/components/responses/NotFound"
+        '500':
+          $ref: "#/components/responses/InternalServerError"
+
   /posts/{postId}/comments:
     get:
       summary: Get all comments

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -532,3 +532,7 @@ tbody tr:last-of-type {
   background-color: unset;
   border: unset;
 }
+
+.whitespace-pre-wrap {
+  white-space: pre-wrap;
+}

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -536,3 +536,7 @@ tbody tr:last-of-type {
 .whitespace-pre-wrap {
   white-space: pre-wrap;
 }
+
+.break-all {
+  word-break: break-all;
+}

--- a/frontend/src/pages/index.page.svelte
+++ b/frontend/src/pages/index.page.svelte
@@ -36,6 +36,7 @@
   import DAOCreateDiscussion from "../routes/DAO/CreateDiscussion.svelte";
   import DAOShowDiscussion from "../routes/DAO/ShowDiscussion.svelte";
   import DAOEditDiscussion from "../routes/DAO/EditDiscussion.svelte";
+  import DAOShowProposal from "../routes/DAO/ShowProposal.svelte";
 
   //https://github.com/EmilTholin/svelte-routing/issues/41
   import { globalHistory } from "svelte-routing/src/history";
@@ -107,6 +108,7 @@
         <Route path="/dao/membership" component={DAOMembership} />
         <Route path="/dao/metamask" component={DAOMetamaskRequired} />
         <Route path="/dao/createProposal" component={DAOCreateProposal} />
+        <Route path="/dao/proposals/:proposalId" component={DAOShowProposal} />
         <Route path="/dao/castVotes/:blockNumber" component={DAOCastVotes} />
         <Route
           path="/dao/executeProposals/:blockNumber"

--- a/frontend/src/routes/DAO/CastVotes.svelte
+++ b/frontend/src/routes/DAO/CastVotes.svelte
@@ -12,7 +12,7 @@
   import { daoConfig, daoContract } from "../../ts/daoStore";
   import { userEthereumAddress } from "../../ts/ethStore";
   import { error, isSubmitting } from "../../ts/mainStore";
-  import { proposalCreatedEvents, votingSlots } from "../../ts/proposalStore";
+  import { proposalStore, votingSlots } from "../../ts/proposalStore";
   import {
     checkUndefinedProvider,
     ensureSameChainId,
@@ -82,15 +82,12 @@
             await $daoContract.votingSlots(blockNumber, index)
           ).toString();
 
-          const event = await proposalCreatedEvents.get(
-            proposalId,
-            $daoContract
-          );
+          const proposal = await proposalStore.get(proposalId, $daoContract);
 
           return {
-            description: event.event.args[8],
-            id: event.proposalId,
-            proposer: event.event.args[1],
+            description: proposal.description,
+            id: proposal.id,
+            proposer: proposal.proposer,
           };
         }
       )

--- a/frontend/src/routes/DAO/ExecuteProposals.svelte
+++ b/frontend/src/routes/DAO/ExecuteProposals.svelte
@@ -9,7 +9,7 @@
     daoContract,
   } from "../../ts/daoStore";
   import { error, isSubmitting } from "../../ts/mainStore";
-  import { proposalCreatedEvents, votingSlots } from "../../ts/proposalStore";
+  import { proposalStore, votingSlots } from "../../ts/proposalStore";
   import {
     checkUndefinedProvider,
     ensureSameChainId,
@@ -28,7 +28,7 @@
     ensureSameChainId($daoConfig?.chainId);
 
     if (
-      $proposalCreatedEvents === null ||
+      $proposalStore === null ||
       $votingSlots === null ||
       $currentBlockTimestamp === null
     ) {
@@ -58,19 +58,17 @@
             $daoContract.proposalEta(proposalId),
           ]);
 
-          const event = (
-            await proposalCreatedEvents.get(proposalId, $daoContract)
-          ).event;
+          const proposal = await proposalStore.get(proposalId, $daoContract);
 
           return {
-            calldatas: event.args[5],
-            description: event.args[8],
+            calldatas: proposal.calldatas,
+            description: proposal.description,
             eta: proposalEta < $currentBlockTimestamp ? 0 : proposalEta,
             id: proposalId.toString(),
-            proposer: event.args[1],
+            proposer: proposal.proposer,
             state: proposalState,
-            targets: event.args[2],
-            values: event.args[3],
+            targets: proposal.targets,
+            values: proposal.values,
           };
         }
       )

--- a/frontend/src/routes/DAO/ShowDiscussion.svelte
+++ b/frontend/src/routes/DAO/ShowDiscussion.svelte
@@ -11,7 +11,8 @@
   import { API } from "../../ts/api";
   import { error, user } from "../../ts/mainStore";
   import type { Comment, Post } from "../../types/forum";
-  import { navigate } from "svelte-routing";
+  import { Link } from "svelte-routing";
+  import truncateString from "../../utils/truncateString";
 
   export let postId: string;
 
@@ -66,6 +67,21 @@
         {/if}
       </div>
     </div>
+
+    {#if post.proposal_ids?.length > 0}
+      <p class="mt-2 mb-2 text-secondary-900">
+        Linked to the following proposals:
+      </p>
+      <ul class="mt-2 mb-20">
+        {#each post.proposal_ids as proposalId}
+          <li>
+            <Link to="/dao/proposals/{proposalId}"
+              >{truncateString(proposalId, 40)}</Link
+            >
+          </li>
+        {/each}
+      </ul>
+    {/if}
 
     <PostThreadItem item={post} />
 

--- a/frontend/src/routes/DAO/ShowProposal.svelte
+++ b/frontend/src/routes/DAO/ShowProposal.svelte
@@ -137,5 +137,15 @@
     {:else}
       <Link to={`/dao/discussion/${discussion.id}`}>{discussion.title}</Link>
     {/if}
+
+    <p class="bold mb-2">Calls</p>
+    {#each proposal.targets as target, index}
+      <p class="mt-2 mb-2">Call {index + 1}:</p>
+      <ul class="mt-2 mb-2">
+        <li class="break-all">Target: {target}</li>
+        <li>Value: {proposal.values[index]}</li>
+        <li class="break-all">Calldata: {proposal.calldatas[index]}</li>
+      </ul>
+    {/each}
   {/if}
 </Navigation>

--- a/frontend/src/routes/DAO/ShowProposal.svelte
+++ b/frontend/src/routes/DAO/ShowProposal.svelte
@@ -1,0 +1,109 @@
+<script lang="ts">
+  import Spinner from "../../components/Spinner.svelte";
+  import Navigation from "../../components/DAO/Navigation.svelte";
+  import {
+    proposalCreatedEvents,
+    type ProposalCreatedEvent,
+  } from "../../ts/proposalStore";
+  import {
+    currentBlockTimestamp,
+    daoContract,
+    membershipStatusValue,
+  } from "../../ts/daoStore";
+  import { futureBlockDate } from "../../utils/futureBlockDate";
+  import { Link } from "svelte-routing";
+  import humanizeDuration from "humanize-duration";
+
+  export let proposalId: string;
+
+  let proposal: ProposalCreatedEvent;
+  let isLoading = true;
+  let proposalEta = 0;
+  let proposalState = 0;
+
+  $: {
+    if ($daoContract === null) {
+      isLoading = true;
+    } else {
+      prepareView();
+    }
+  }
+
+  async function prepareView() {
+    [proposal, proposalState] = await Promise.all([
+      proposalCreatedEvents.get(proposalId, $daoContract),
+      $daoContract.state(proposalId),
+    ]);
+
+    if (proposalState === 5) {
+      proposalEta = await $daoContract.proposalEta(proposalId);
+    }
+
+    isLoading = false;
+  }
+</script>
+
+<Navigation>
+  {#if isLoading}
+    <Spinner />
+  {:else}
+    <h2>Details about proposal</h2>
+
+    <p class="bold">Proposer</p>
+    <p>{proposal.event.args[1]}</p>
+
+    <p class="bold">Description</p>
+    <p>{proposal.event.args[8]}</p>
+
+    <p class="bold">State</p>
+    {#if proposalState === 0}
+      <p>
+        Vote of proposal is scheduled for #{proposal.event.args[6]}
+        {#await futureBlockDate(proposal.event.args[6])}(approx ...){:then date}(approx
+          {date}){/await}
+      </p>
+    {:else if proposalState === 1}
+      <p>
+        Vote for proposal is open until #{proposal.event.args[7]}
+        {#await futureBlockDate(proposal.event.args[7])}(approx ...){:then date}(approx
+          {date}){/await}.
+        {#if $membershipStatusValue === 3}
+          <Link to={`/dao/castVotes/${proposal.event.args[6]}`}>Cast vote!</Link
+          >
+        {/if}
+      </p>
+    {:else if proposalState === 2}
+      <p>The proposal has been cancelled.</p>
+    {:else if proposalState === 3}
+      <p>The proposal has been denied.</p>
+    {:else if proposalState === 4}
+      <p>
+        The vote for the proposal was successful.
+        {#if $membershipStatusValue === 3}
+          <Link to={`/dao/executeProposals/${proposal.event.args[6]}`}
+            >Enqueue proposal</Link
+          >
+        {/if}
+      </p>
+    {:else if proposalState === 5}
+      {#if proposalEta === 0}
+        <p>
+          The proposal is ready for execution.
+          {#if $membershipStatusValue === 3}
+            <Link to={`/dao/executeProposals/${proposal.event.args[6]}`}
+              >Execute proposal</Link
+            >
+          {/if}
+        </p>
+      {:else}
+        The proposal can be executed in {humanizeDuration(
+          (proposalEta - $currentBlockTimestamp) * 1000
+        )}.
+      {/if}
+    {:else if proposalState === 6}
+      <p>The time to execute the proposal has expired.</p>
+    {:else if proposalState === 7}
+      <p>The proposal has been executed.</p>
+    {/if}
+  {/if}
+</Navigation>

--- a/frontend/src/routes/DAO/Votes.svelte
+++ b/frontend/src/routes/DAO/Votes.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onDestroy } from "svelte";
-  import { navigate } from "svelte-routing";
+  import { Link, navigate } from "svelte-routing";
   import Navigation from "../../components/DAO/Navigation.svelte";
   import ExtraOrdinaryAssemblies from "../../components/DAO/votes/ExtraOrdinaryAssemblies.svelte";
   import {
@@ -246,7 +246,11 @@
         {#if slotInfo.proposalInfos.length > 0}
           <ul>
             {#each slotInfo.proposalInfos as proposalInfo, i}
-              <li>Proposal {i + 1}: {proposalInfo.proposalDescription}</li>
+              <li>
+                <Link to="/dao/proposals/{proposalInfo.proposalId}"
+                  >Proposal {i + 1}</Link
+                >
+              </li>
             {/each}
           </ul>
         {:else}

--- a/frontend/src/routes/DAO/Votes.svelte
+++ b/frontend/src/routes/DAO/Votes.svelte
@@ -12,7 +12,7 @@
   } from "../../ts/daoStore";
   import { provider } from "../../ts/ethStore";
   import { isSubmitting } from "../../ts/mainStore";
-  import { proposalCreatedEvents, votingSlots } from "../../ts/proposalStore";
+  import { proposalStore, votingSlots } from "../../ts/proposalStore";
   import {
     checkUndefinedProvider,
     ensureSameChainId,
@@ -154,8 +154,8 @@
   }
 
   async function loadProposalDescription(proposalId: string): Promise<string> {
-    const event = await proposalCreatedEvents.get(proposalId, $daoContract);
-    return event.event.args[8];
+    const event = await proposalStore.get(proposalId, $daoContract);
+    return event.description;
   }
 
   async function getVotingSlotState(

--- a/frontend/src/routes/DAO/Votes.svelte
+++ b/frontend/src/routes/DAO/Votes.svelte
@@ -19,6 +19,7 @@
   } from "../../utils/ethHelpers";
   import formatDateTime from "../../utils/formatDateTime";
   import { futureBlockDate } from "../../utils/futureBlockDate";
+  import truncateString from "../../utils/truncateString";
 
   let viewVotingSlots: VotingSlot[] = [];
   let slotCloseTime: number = 0;
@@ -248,7 +249,10 @@
             {#each slotInfo.proposalInfos as proposalInfo, i}
               <li>
                 <Link to="/dao/proposals/{proposalInfo.proposalId}"
-                  >Proposal {i + 1}</Link
+                  >Proposal {i + 1}: {truncateString(
+                    proposalInfo.proposalDescription,
+                    30
+                  )}</Link
                 >
               </li>
             {/each}

--- a/frontend/src/ts/api.ts
+++ b/frontend/src/ts/api.ts
@@ -303,6 +303,8 @@ export const API = {
     createPost: (postInput: PostInput) =>
       forumToken.post(`posts`, { json: postInput }).json<Post>(),
     getPost: (postId: PostId) => forum.get(`posts/${postId}`).json<Post>(),
+    getPostByProposalId: (proposalId: string) =>
+      forum.get(`posts/byProposalId/${proposalId}`).json<Post>(),
     deletePost: (postId: PostId) => forumToken.delete(`posts/${postId}`),
     updatePost: (postId: PostId, postInput: PostInput) =>
       forumToken.put(`posts/${postId}`, { json: postInput }).json<Post>(),

--- a/frontend/src/ts/proposalStore.ts
+++ b/frontend/src/ts/proposalStore.ts
@@ -3,7 +3,7 @@ import { derived, get, writable, type Readable } from "svelte/store";
 import { daoContract } from "./daoStore";
 import { userEthereumAddress } from "./ethStore";
 
-interface ProposalCreatedEvent {
+export interface ProposalCreatedEvent {
   proposalId: string;
   event: Event;
 }

--- a/frontend/src/ts/proposalStore.ts
+++ b/frontend/src/ts/proposalStore.ts
@@ -1,4 +1,4 @@
-import type { BigNumber, Contract, Event } from "ethers";
+import type { BigNumber, Bytes, Contract, Event } from "ethers";
 import { derived, get, writable, type Readable } from "svelte/store";
 import { daoContract } from "./daoStore";
 import { userEthereumAddress } from "./ethStore";
@@ -8,22 +8,35 @@ export interface ProposalCreatedEvent {
   event: Event;
 }
 
-const proposalEvents = writable<[] | ProposalCreatedEvent[]>([]);
+export interface Proposal {
+  calldatas: Bytes[];
+  description: string;
+  endBlock: number;
+  id: string;
+  proposer: string;
+  signatures: string[];
+  startBlock: number;
+  targets: string[];
+  values: string[];
+}
 
-export const proposalCreatedEvents = {
+const proposals = writable<Proposal[]>([]);
+
+export const proposalStore = {
   // subscribe to the cart store
-  subscribe: proposalEvents.subscribe,
+  subscribe: proposals.subscribe,
   // custom logic
-  async get(id: string, $daoContract): Promise<ProposalCreatedEvent> {
-    let values = get(proposalEvents);
-    const result = values.find(({ proposalId }) => proposalId === id);
+  async get(proposalId: string, $daoContract): Promise<Proposal> {
+    let values = get(proposals);
+    const result = values.find(({ id }) => proposalId === id);
+
     if (result) {
       return result;
     } else {
       return await Promise.resolve(
         $daoContract.queryFilter(
           $daoContract.filters.DAOProposalCreated(
-            id,
+            proposalId,
             null,
             null,
             null,
@@ -36,14 +49,21 @@ export const proposalCreatedEvents = {
           )
         )
       ).then((events: Event[]) => {
-        let newItem: ProposalCreatedEvent = {
-          proposalId: events[0].args[0].toString(),
-          event: events[0],
+        let newProposal: Proposal = {
+          calldatas: events[0].args[5],
+          description: events[0].args[8],
+          endBlock: events[0].args[7].toNumber(),
+          id: proposalId,
+          proposer: events[0].args[1],
+          signatures: events[0].args[4],
+          startBlock: events[0].args[6].toNumber(),
+          targets: events[0].args[2],
+          values: events[0].args[3],
         };
-        proposalEvents.update((items) => {
-          return [...items, newItem];
+        proposals.update((items) => {
+          return [...items, newProposal];
         });
-        return newItem;
+        return newProposal;
       });
     }
   },

--- a/frontend/src/types/generated-forum-types.ts
+++ b/frontend/src/types/generated-forum-types.ts
@@ -132,6 +132,27 @@ export interface paths {
       };
     };
   };
+  "/posts/byProposalId/{proposalId}": {
+    /** Get a specific post by proposal id */
+    get: {
+      parameters: {
+        path: {
+          /** @description ID of the proposal */
+          proposalId: string;
+        };
+      };
+      responses: {
+        /** @description OK */
+        200: {
+          content: {
+            "application/json": components["schemas"]["Post"];
+          };
+        };
+        404: components["responses"]["NotFound"];
+        500: components["responses"]["InternalServerError"];
+      };
+    };
+  };
   "/posts/{postId}/comments": {
     /** Get all comments */
     get: {


### PR DESCRIPTION
The main idea of this PR is to show the link between a discussion and proposals. I created a dedicated detail page for proposals, where  the discussion is mentioned:

![FireShot Capture 006 - FlatFeeStack - localhost](https://github.com/flatfeestack/flatfeestack/assets/7010698/028b077e-2ea5-42f1-bcbe-4130b4e0c731)

For discussions, the proposals are linked on top:

![FireShot Capture 007 - FlatFeeStack - localhost](https://github.com/flatfeestack/flatfeestack/assets/7010698/6d75c80e-1a46-42e3-80b2-8a260e96ee53)

But as always, I stumbled upon some refactoring and issues:

- In #218, I forgot to map the proposal ids in the different API endpoints of the forum.
- I added a new endpoint in the forum that allows to retrieve a post for a given proposal id.
- During the DAO development, a store was introduced to cache the `proposal created events`. Those were parsed in different ways across the views. I harmonised this by translating the event `args` to object properties.
- The votes overview now links to the new `Show proposal` page. The proposal description is truncated to 30 characters to avoid page overflow.

There is potential to further iterate on this:

- Allow to vote / queue / execute proposals on this `ShowProposal` page.
- As we have contract addresses and calls in the frontend, we could decode the calldata on the `ShowProposal`, showing what the proposer intends to do.
- Resolve the state of the proposal in the `proposalStore`, as it's used in the most places.
- Link `ShowProposal` from `ExecuteProposals` and `CastVotes`.