### PR TITLE
Fix git email address parking possibility

### DIFF
--- a/backend/api/email.go
+++ b/backend/api/email.go
@@ -77,7 +77,7 @@ func AddGitEmail(w http.ResponseWriter, r *http.Request, user *db.UserDetail) {
 		return
 	}
 
-	err = clnt.SendAddGit(body.Email, addGitEmailToken, lang(r))
+	err = clnt.SendAddGit(user.Id, body.Email, addGitEmailToken, lang(r))
 	if err != nil {
 		log.Errorf("Could not send add git email: %v", err)
 		utils.WriteErrorf(w, http.StatusInternalServerError, "Oops something went wrong with sending the email. Please try again.")
@@ -91,6 +91,12 @@ func RemoveGitEmail(w http.ResponseWriter, r *http.Request, user *db.UserDetail)
 	err := db.DeleteGitEmail(user.Id, email)
 	if err != nil {
 		log.Errorf("Could not remove email, Invalid email: %v", err)
+		utils.WriteErrorf(w, http.StatusBadRequest, "Oops could not remove email. Please try again.")
+		return
+	}
+	err = db.DeleteGitEmailFromUserEmailsSent(user.Id, email)
+	if err != nil {
+		log.Errorf("Could not remove user emails sent entry: %v", err)
 		utils.WriteErrorf(w, http.StatusBadRequest, "Oops could not remove email. Please try again.")
 		return
 	}

--- a/backend/api/email.go
+++ b/backend/api/email.go
@@ -57,6 +57,19 @@ func AddGitEmail(w http.ResponseWriter, r *http.Request, user *db.UserDetail) {
 	}
 	addGitEmailToken := base32.StdEncoding.EncodeToString(rnd)
 	id := uuid.New()
+
+	c, err := db.CountExistingOrConfirmedGitEmail(user.Id, body.Email)
+	if err != nil {
+		log.Errorf("Could not save email: %v", err)
+		utils.WriteErrorf(w, http.StatusInternalServerError, "Oops could not save email: Git Email already in use")
+		return
+	}
+	if c > 0 {
+		log.Errorf("Could not save email, either user has entered already or is confirmed, count: %v", c)
+		utils.WriteErrorf(w, http.StatusInternalServerError, "Oops could not save email: Git Email already in use")
+		return
+	}
+
 	err = db.InsertGitEmail(id, user.Id, body.Email, &addGitEmailToken, utils.TimeNow())
 	if err != nil {
 		log.Errorf("Could not save email: %v", err)

--- a/backend/clients/email.go
+++ b/backend/clients/email.go
@@ -286,7 +286,7 @@ func SendTopUpOther(u db.UserDetail) error {
 
 }
 
-func SendAddGit(email string, addGitEmailToken string, lang string) error {
+func SendAddGit(userId uuid.UUID, email string, addGitEmailToken string, lang string) error {
 	var params = map[string]string{}
 	params["token"] = addGitEmailToken
 	params["mailTo"] = email
@@ -296,7 +296,7 @@ func SendAddGit(email string, addGitEmailToken string, lang string) error {
 	params["key"] = KeyAddGit + email
 
 	return prepareSendEmail(
-		nil,
+		&userId,
 		params,
 		KeyAddGit,
 		"Validate your git email",

--- a/backend/db/emails.go
+++ b/backend/db/emails.go
@@ -95,6 +95,22 @@ func DeleteGitEmail(uid uuid.UUID, email string) error {
 	return handleErrMustInsertOne(res)
 }
 
+func DeleteGitEmailFromUserEmailsSent(uid uuid.UUID, email string) error {
+	//TODO: find a better solution in future that allows multiple mails be sent to same mail address but still has spam protection
+	stmt, err := dbLib.DB.Prepare("DELETE FROM user_emails_sent WHERE email=$1 AND user_id=$2 and email_type=$3")
+	if err != nil {
+		return fmt.Errorf("prepare DELETE FROM user_emails_sent for %v and user_id %v statement event: %v", email, uid, err)
+	}
+	defer dbLib.CloseAndLog(stmt)
+
+	var res sql.Result
+	res, err = stmt.Exec(email, uid, "add-git"+email)
+	if err != nil {
+		return err
+	}
+	return handleErrMustInsertOne(res)
+}
+
 func FindUserByGitEmail(gitEmail string) (*uuid.UUID, error) {
 	var uid uuid.UUID
 	err := dbLib.DB.

--- a/backend/db/emails.go
+++ b/backend/db/emails.go
@@ -34,6 +34,21 @@ func FindGitEmailsByUserId(uid uuid.UUID) ([]GitEmail, error) {
 	return gitEmails, nil
 }
 
+func CountExistingOrConfirmedGitEmail(uid uuid.UUID, email string) (int, error) {
+	var c int
+	err := dbLib.DB.
+		QueryRow(`SELECT count(*) AS c FROM git_email WHERE (user_id=$1 or confirmed_at is not null) and email=$2`, uid, email).
+		Scan(&c)
+	switch err {
+	case sql.ErrNoRows:
+		return 0, nil
+	case nil:
+		return c, nil
+	default:
+		return c, err
+	}
+}
+
 func InsertGitEmail(id uuid.UUID, uid uuid.UUID, email string, token *string, now time.Time) error {
 	stmt, err := dbLib.DB.Prepare("INSERT INTO git_email(id, user_id, email, token, created_at) VALUES($1, $2, $3, $4, $5)")
 	if err != nil {

--- a/backend/db/emails_test.go
+++ b/backend/db/emails_test.go
@@ -22,6 +22,34 @@ func TestGitEmailInsert(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+func TestCountExistingOrConfirmedGitEmail(t *testing.T) {
+	setup()
+	defer teardown()
+
+	uid := insertTestUser(t, "foo@bar.ch").Id
+	uid2 := insertTestUser(t, "bar@foo.ch").Id
+	uid3 := insertTestUser(t, "meh@foo.ch").Id
+
+	c, err := CountExistingOrConfirmedGitEmail(uid, "foo@bar.ch")
+	assert.Equal(t, 0, c)
+	err = InsertGitEmail(uuid.New(), uid, "foo@bar.ch", stringPointer("A"), time.Now())
+	assert.Nil(t, err)
+
+	c, err = CountExistingOrConfirmedGitEmail(uid2, "foo@bar.ch")
+	assert.Equal(t, 0, c)
+	err = InsertGitEmail(uuid.New(), uid2, "foo@bar.ch", stringPointer("B"), time.Now())
+	assert.Nil(t, err)
+
+	c, err = CountExistingOrConfirmedGitEmail(uid, "foo@bar.ch")
+	assert.Equal(t, 1, c)
+
+	err = ConfirmGitEmail("foo@bar.ch", "A", time.Time{})
+	assert.Nil(t, err)
+
+	c, err = CountExistingOrConfirmedGitEmail(uid3, "foo@bar.ch")
+	assert.Equal(t, 1, c)
+}
+
 func TestGitEmailFind(t *testing.T) {
 	setup()
 	defer teardown()

--- a/backend/db/emails_test.go
+++ b/backend/db/emails_test.go
@@ -85,6 +85,24 @@ func TestGitEmailDelete(t *testing.T) {
 	assert.Equal(t, 0, len(emails))
 }
 
+func TestGitEmailFromUserEmailsSentDelete(t *testing.T) {
+	setup()
+	defer teardown()
+
+	uid := insertTestUser(t, "foo@bar.ch").Id
+
+	err := InsertEmailSent(uuid.New(), &uid, "foo@bar.ch", "add-gitfoo@bar.ch", time.Now())
+	err = InsertEmailSent(uuid.New(), &uid, "bar@foo.ch", "add-gitbar@foo.ch", time.Now())
+	err = DeleteGitEmailFromUserEmailsSent(uid, "bar@foo.ch")
+	assert.Nil(t, err)
+	c, err := CountEmailSentById(uid, "add-gitfoo@bar.ch")
+	assert.Nil(t, err)
+	assert.Equal(t, 1, c)
+	c, err = CountEmailSentById(uid, "add-gitbar@foo.ch")
+	assert.Nil(t, err)
+	assert.Equal(t, 0, c)
+}
+
 func TestGitEmailConfirm(t *testing.T) {
 	setup()
 	defer teardown()

--- a/backend/db/init.sql
+++ b/backend/db/init.sql
@@ -57,6 +57,8 @@ CREATE TABLE IF NOT EXISTS git_email (
 );
 CREATE INDEX IF NOT EXISTS git_email_user_id_idx ON git_email(user_id);
 
+ALTER TABLE git_email DROP CONSTRAINT IF EXISTS git_email_email_key; /* don't make unique to prevent users blocking emails */
+
 CREATE TABLE IF NOT EXISTS sponsor_event (
     id            UUID PRIMARY KEY,
     repo_id       UUID CONSTRAINT sponsor_event_repo_id_fk REFERENCES repo(id),

--- a/backend/db/init.sql
+++ b/backend/db/init.sql
@@ -49,15 +49,13 @@ CREATE INDEX IF NOT EXISTS repo_name_idx ON repo(name);
 CREATE TABLE IF NOT EXISTS git_email (
     id           UUID PRIMARY KEY,
     user_id      UUID CONSTRAINT git_email_user_id_fk REFERENCES users(id),
-    email        VARCHAR(255) UNIQUE NOT NULL,
+    email        VARCHAR(255) NOT NULL,
     token        VARCHAR(32),
     confirmed_at TIMESTAMP,
     created_at   TIMESTAMP NOT NULL,
     UNIQUE(user_id, email, token)
 );
 CREATE INDEX IF NOT EXISTS git_email_user_id_idx ON git_email(user_id);
-
-ALTER TABLE git_email DROP CONSTRAINT IF EXISTS git_email_email_key; /* don't make unique to prevent users blocking emails */
 
 CREATE TABLE IF NOT EXISTS sponsor_event (
     id            UUID PRIMARY KEY,

--- a/frontend/src/routes/Settings.svelte
+++ b/frontend/src/routes/Settings.svelte
@@ -176,7 +176,9 @@
   <p class="p-2 m-2">
     If you have multiple git email addresses, you can connect these addresses to
     your FlatFeeStack account. You must verify your git email address. Once
-    validated, the confirmed date will show the validation date.
+    validated, the confirmed date will show the validation date. In case you
+    didn't receive a confirmation email, please remove and re-add your git email
+    address.
   </p>
 
   <div class="min-w20 container">


### PR DESCRIPTION
Fix users being able to block a git_email by adding it and never confirming it, thus disallowing any other users to add it.

Now only allows adding if the user hasn't already added it or it's not confirmed yet.

Initially had a `alter table drop constraint` for the unique, but SQLite doesn't know `constraint` and only `drop index`.
Then SQLite automatically names the indexes (not very pretty), and the index to remove was `sqlite_autoindex_git_email_2`.

I thought, oh hey, not very nice, but oh well, add another `DROP index if exists sqlite_autoindex_git_email_2`, but that results in: `index associated with UNIQUE or PRIMARY KEY constraint cannot be dropped`

tl;dr: need to drop the unique index and have to delete the DB's, and start up again because of SQLite and this change being needed