### PR TITLE
Fix payout for staging instance

### DIFF
--- a/frontend/src/routes/Income.svelte
+++ b/frontend/src/routes/Income.svelte
@@ -21,10 +21,14 @@
   let payoutSignature: PayoutResponse;
 
   async function requestPayout(selectedCurrency: "ETH" | "GAS" | "USD") {
-    payoutSignature = await API.user.requestPayout(selectedCurrency);
+    try {
+      payoutSignature = await API.user.requestPayout(selectedCurrency);
 
-    if (selectedCurrency !== "GAS") {
-      ethSignature = splitSignature(payoutSignature.signature);
+      if (selectedCurrency !== "GAS") {
+        ethSignature = splitSignature(payoutSignature.signature);
+      }
+    } catch (e) {
+      $error = e.message;
     }
   }
 

--- a/payout/api_test.go
+++ b/payout/api_test.go
@@ -44,7 +44,7 @@ func TestPostSignEth(t *testing.T) {
 // the resulting signature (r, s, v) are the same as in the generateSignature function in the test helpers
 func TestPostSignUsdc(t *testing.T) {
 	opts = &Opts{}
-	opts.Ethereum.PrivateKey = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+	opts.Usdc.PrivateKey = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
 
 	t.Run("should generate a signature for USDC", func(t *testing.T) {
 		userId, _ := uuid.Parse("4fed2b83-f968-45cc-8869-a36f844cefdb")

--- a/payout/eth.go
+++ b/payout/eth.go
@@ -126,7 +126,12 @@ func getEthSignature(data PayoutRequest, symbol string) (PayoutResponse, error) 
 		Type: abi.Type{T: abi.StringTy},
 	})
 
-	privateKey, err := crypto.HexToECDSA(opts.Ethereum.PrivateKey)
+	correspondingPrivateKey, err := privateKeyFromOpts(symbol)
+	if err != nil {
+		return PayoutResponse{}, err
+	}
+
+	privateKey, err := crypto.HexToECDSA(correspondingPrivateKey)
 	if err != nil {
 		return PayoutResponse{}, err
 	}
@@ -150,4 +155,16 @@ func getEthSignature(data PayoutRequest, symbol string) (PayoutResponse, error) 
 		EncodedUserId: hexutil.Encode(encodedUserId[:]),
 		Signature:     hexutil.Encode(signature),
 	}, nil
+}
+
+func privateKeyFromOpts(symbol string) (string, error) {
+	log.Printf(symbol)
+	switch symbol {
+	case "ETH":
+		return opts.Ethereum.PrivateKey, nil
+	case "USDC":
+		return opts.Usdc.PrivateKey, nil
+	default:
+		return "", errors.New("unknown currency")
+	}
 }

--- a/payout/eth.go
+++ b/payout/eth.go
@@ -158,7 +158,6 @@ func getEthSignature(data PayoutRequest, symbol string) (PayoutResponse, error) 
 }
 
 func privateKeyFromOpts(symbol string) (string, error) {
-	log.Printf(symbol)
 	switch symbol {
 	case "ETH":
 		return opts.Ethereum.PrivateKey, nil


### PR DESCRIPTION
As the staging instance uses a different private key for the two payout contracts, we need to load the correct private key when generating a signature.