### PR TITLE
Let Renovate keep OpenZeppelin contracts on v4.8

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,13 @@
   "packageRules": [
     {
       "matchPackageNames": [
+        "@openzeppelin/contracts",
+        "@openzeppelin/contracts-upgradeable"
+      ],
+      "allowedVersions": "<=4.8"
+    },
+    {
+      "matchPackageNames": [
         "ch.qos.logback:logback-classic"
       ],
       "matchPaths": [
@@ -105,7 +112,9 @@
     }
   ],
   "postUpdateOptions": [
-    "gomodTidy", "npmDedupe", "pnpmDedupe"
+    "gomodTidy",
+    "npmDedupe",
+    "pnpmDedupe"
   ],
   "schedule": [
     "before 12pm every thursday"


### PR DESCRIPTION
As we won't update this version due to the code changes required in the DAO, but still want to receive updates for the other dependencies, we lock the dependency in Renovate for now.