### PR TITLE
Hide crypto currency pay-in on production

### DIFF
--- a/frontend/src/components/PaymentSelection.svelte
+++ b/frontend/src/components/PaymentSelection.svelte
@@ -8,10 +8,15 @@
   import type { Plan } from "../types/backend";
 
   // List of tab items with labels, values and assigned components
-  let items = [
-    { label: "Credit Card", value: 1, component: FiatTab },
-    { label: "Crypto Currencies", value: 2, component: CryptoTab },
-  ];
+  let items = [{ label: "Credit Card", value: 1, component: FiatTab }];
+
+  if ($config.env == "local" || $config.env == "staging") {
+    items.push({
+      label: "Crypto Currencies",
+      value: 2,
+      component: CryptoTab,
+    });
+  }
 
   let currentFreq: number = 365;
   let currentSeats = 1;


### PR DESCRIPTION
This feature is not yet configured and likely the code needs some updates, so the option will be disabled for now on production.