### PR TITLE
Properly handle non-ETH errors in Income component

### DIFF
--- a/frontend/src/routes/Income.svelte
+++ b/frontend/src/routes/Income.svelte
@@ -67,8 +67,12 @@
         ethSignature.s
       );
     } catch (exception) {
-      console.error(exception);
-      $error = exception.data.data.reason;
+      if (exception.data?.data === undefined) {
+        // we deal with a regular error, not one a "revert" from the blockchain
+        $error = exception.message;
+      } else {
+        $error = exception.data.data.reason;
+      }
       resetViewAfterPayout();
     }
 


### PR DESCRIPTION
It can be that `exception.data.data` is undefined - it is only filled when the blockchain sends back a `revert`. With this commit, this is properly handled.