### PR TITLE
Use bump strategy for NPM

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -109,6 +109,12 @@
         "minor",
         "patch"
       ]
+    },
+    {
+      "matchManagers": [
+        "npm"
+      ],
+      "rangeStrategy": "bump"
     }
   ],
   "postUpdateOptions": [


### PR DESCRIPTION
Renovate seems to only recommend updates for NPM when there is a new version that is outside the range defined in `package.json`. However, we always want to have latest, which should be possible by defining `bump`.