### PR TITLE
Improve `Ensure same chain ID` component

### DIFF
--- a/frontend/src/components/DAO/Navigation.svelte
+++ b/frontend/src/components/DAO/Navigation.svelte
@@ -20,6 +20,7 @@
   } from "../../ts/daoStore";
   import {
     getChainId,
+    lastEthRoute,
     provider,
     signer,
     userEthereumAddress,
@@ -92,6 +93,7 @@
     if (currentChainId === undefined) {
       showMetaMaskRequired();
     } else if (currentChainId !== $daoConfig.chainId) {
+      $lastEthRoute = window.location.pathname;
       navigate(
         `/differentChainId?required=${$daoConfig.chainId}&actual=${currentChainId}`
       );

--- a/frontend/src/components/DAO/Navigation.svelte
+++ b/frontend/src/components/DAO/Navigation.svelte
@@ -12,20 +12,26 @@
   import { BrowserProvider } from "ethers";
   import { onMount } from "svelte";
   import Fa from "svelte-fa";
-  import { links } from "svelte-routing";
+  import { links, navigate } from "svelte-routing";
   import {
     councilMembers,
     daoConfig,
     membershipStatusValue,
   } from "../../ts/daoStore";
-  import { provider, signer, userEthereumAddress } from "../../ts/ethStore";
+  import {
+    getChainId,
+    provider,
+    signer,
+    userEthereumAddress,
+  } from "../../ts/ethStore";
   import { isSubmitting } from "../../ts/mainStore";
-  import { ensureSameChainId } from "../../utils/ethHelpers";
   import membershipStatusMapping from "../../utils/membershipStatusMapping";
   import setSigner from "../../utils/setSigner";
+  import showMetaMaskRequired from "../../utils/showMetaMaskRequired";
   import truncateEthAddress from "../../utils/truncateEthereumAddress";
   import NavItem from "../NavItem.svelte";
   import Spinner from "../Spinner.svelte";
+  import EnsureSameChainId from "../EnsureSameChainId.svelte";
 
   let pathname = "/";
   if (typeof window !== "undefined") {
@@ -33,6 +39,8 @@
   }
 
   let membershipStatus: string;
+
+  export let requiresChainId: number | undefined = undefined;
 
   onMount(async () => {
     await setProvider();
@@ -79,8 +87,17 @@
   }
 
   async function triggerSetSigner() {
-    ensureSameChainId($daoConfig.chainId);
-    await setSigner($provider);
+    const currentChainId = await getChainId();
+
+    if (currentChainId === undefined) {
+      showMetaMaskRequired();
+    } else if (currentChainId !== $daoConfig.chainId) {
+      navigate(
+        `/differentChainId?required=${$daoConfig.chainId}&actual=${currentChainId}`
+      );
+    } else {
+      await setSigner($provider);
+    }
   }
 </script>
 
@@ -183,6 +200,10 @@
     </nav>
   </div>
   <div class="content">
+    {#if requiresChainId}
+      <EnsureSameChainId requiredChainId={requiresChainId} />
+    {/if}
+
     {#if $isSubmitting}
       <Spinner />
     {:else}

--- a/frontend/src/components/EnsureSameChainId.svelte
+++ b/frontend/src/components/EnsureSameChainId.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { navigate } from "svelte-routing";
-  import { chainId } from "../ts/ethStore";
+  import { chainId, lastEthRoute } from "../ts/ethStore";
 
   export let requiredChainId: number | undefined;
 
@@ -10,6 +10,7 @@
       $chainId !== null &&
       $chainId !== requiredChainId
     ) {
+      $lastEthRoute = window.location.pathname;
       navigate(
         `/differentChainId?required=${requiredChainId}&actual=${$chainId}`
       );

--- a/frontend/src/components/EnsureSameChainId.svelte
+++ b/frontend/src/components/EnsureSameChainId.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import { navigate } from "svelte-routing";
+  import { chainId } from "../ts/ethStore";
+
+  export let requiredChainId: number | undefined;
+
+  $: {
+    if (
+      requiredChainId !== undefined &&
+      $chainId !== null &&
+      $chainId !== requiredChainId
+    ) {
+      navigate(
+        `/differentChainId?required=${requiredChainId}&actual=${$chainId}`
+      );
+    }
+  }
+</script>

--- a/frontend/src/routes/DAO/CastVotes.svelte
+++ b/frontend/src/routes/DAO/CastVotes.svelte
@@ -4,6 +4,7 @@
     faQuestion,
     faXmark,
   } from "@fortawesome/free-solid-svg-icons";
+  import type { EventLog } from "ethers";
   import { onDestroy, onMount } from "svelte";
   import Fa from "svelte-fa";
   import { navigate } from "svelte-routing";
@@ -16,11 +17,7 @@
   import { userEthereumAddress } from "../../ts/ethStore";
   import { error, isSubmitting } from "../../ts/mainStore";
   import { proposalStore, votingSlots } from "../../ts/proposalStore";
-  import {
-    checkUndefinedProvider,
-    ensureSameChainId,
-  } from "../../utils/ethHelpers";
-  import type { EventLog } from "ethers";
+  import { checkUndefinedProvider } from "../../utils/ethHelpers";
 
   interface VoteValues {
     canVote: boolean;
@@ -51,8 +48,6 @@
   checkUndefinedProvider();
 
   $: {
-    ensureSameChainId($daoConfig?.chainId);
-
     if ($votingSlots === null) {
       $isSubmitting = true;
     } else if (proposals.length === 0) {
@@ -71,7 +66,6 @@
       $userEthereumAddress,
       blockNumber
     )) as bigint;
-    console.log(votingPower);
     if (votingPower < 1n) {
       $error = "You are not allowed to vote in this cycle.";
       navigate("/dao/votes");
@@ -191,7 +185,7 @@
   }
 </style>
 
-<Navigation>
+<Navigation requiresChainId={$daoConfig.chainId}>
   <h1 class="text-secondary-900">Cast votes</h1>
 
   {#each proposals as proposal, i}

--- a/frontend/src/routes/DAO/Council.svelte
+++ b/frontend/src/routes/DAO/Council.svelte
@@ -8,16 +8,11 @@
   import { councilMembers, daoConfig } from "../../ts/daoStore";
   import { userEthereumAddress } from "../../ts/ethStore";
   import { error, isSubmitting } from "../../ts/mainStore";
-  import {
-    checkUndefinedProvider,
-    ensureSameChainId,
-  } from "../../utils/ethHelpers";
+  import { checkUndefinedProvider } from "../../utils/ethHelpers";
 
   checkUndefinedProvider();
 
   $: {
-    ensureSameChainId($daoConfig?.chainId);
-
     if ($councilMembers === null || $userEthereumAddress === null) {
       $isSubmitting = true;
     } else if (
@@ -35,7 +30,7 @@
   });
 </script>
 
-<Navigation>
+<Navigation requiresChainId={$daoConfig.chainId}>
   <h1 class="text-secondary-900">Council Member functions</h1>
 
   <AddVotingSlot />

--- a/frontend/src/routes/DAO/CreateProposal.svelte
+++ b/frontend/src/routes/DAO/CreateProposal.svelte
@@ -9,6 +9,7 @@
   import RemoveCouncilMember from "../../components/DAO/proposals/RemoveCouncilMember.svelte";
   import RemoveMember from "../../components/DAO/proposals/RemoveMember.svelte";
   import RequestFunds from "../../components/DAO/proposals/RequestFunds.svelte";
+  import { API } from "../../ts/api";
   import {
     daoConfig,
     daoContract,
@@ -18,12 +19,8 @@
   import { signer } from "../../ts/ethStore";
   import { error, isSubmitting } from "../../ts/mainStore";
   import type { Call, ProposalType } from "../../types/dao";
-  import {
-    checkUndefinedProvider,
-    ensureSameChainId,
-  } from "../../utils/ethHelpers";
   import type { Post } from "../../types/forum";
-  import { API } from "../../ts/api";
+  import { checkUndefinedProvider } from "../../utils/ethHelpers";
   import truncateString from "../../utils/truncateString";
 
   checkUndefinedProvider();
@@ -86,10 +83,6 @@
     $isSubmitting = false;
   });
 
-  $: {
-    ensureSameChainId($daoConfig?.chainId);
-  }
-
   function moveToVotesPage() {
     $error = "You are not allowed to view this page.";
     navigate("/dao/home");
@@ -144,7 +137,7 @@
   }
 </style>
 
-<Navigation>
+<Navigation requiresChainId={$daoConfig.chainId}>
   <h1 class="text-secondary-900">Create a proposal</h1>
 
   <div class="wrapper">

--- a/frontend/src/routes/DAO/ExecuteProposals.svelte
+++ b/frontend/src/routes/DAO/ExecuteProposals.svelte
@@ -10,10 +10,7 @@
   } from "../../ts/daoStore";
   import { error, isSubmitting } from "../../ts/mainStore";
   import { proposalStore, votingSlots } from "../../ts/proposalStore";
-  import {
-    checkUndefinedProvider,
-    ensureSameChainId,
-  } from "../../utils/ethHelpers";
+  import { checkUndefinedProvider } from "../../utils/ethHelpers";
   import {
     executeProposal,
     queueProposal,
@@ -25,8 +22,6 @@
   checkUndefinedProvider();
 
   $: {
-    ensureSameChainId($daoConfig?.chainId);
-
     if (
       $proposalStore === null ||
       $votingSlots === null ||
@@ -84,7 +79,7 @@
   });
 </script>
 
-<Navigation>
+<Navigation requiresChainId={$daoConfig?.chainId}>
   <h1 class="text-secondary-900">Execute proposals</h1>
 
   {#each proposals as proposal, i}

--- a/frontend/src/routes/DAO/Membership.svelte
+++ b/frontend/src/routes/DAO/Membership.svelte
@@ -15,10 +15,7 @@
   } from "../../ts/daoStore";
   import { userEthereumAddress } from "../../ts/ethStore";
   import { error } from "../../ts/mainStore";
-  import {
-    checkUndefinedProvider,
-    ensureSameChainId,
-  } from "../../utils/ethHelpers";
+  import { checkUndefinedProvider } from "../../utils/ethHelpers";
 
   let membershipFeePaid = false;
   let walletConnected: boolean;
@@ -46,8 +43,6 @@
   }
 
   $: {
-    ensureSameChainId($daoConfig?.chainId);
-
     if (
       $membershipStatusValue !== null &&
       $membershipContract !== null &&
@@ -134,7 +129,7 @@
   }
 </style>
 
-<Navigation>
+<Navigation requiresChainId={$daoConfig?.chainId}>
   {#if !walletConnected}
     <div class="centerContainer">
       <p>Please connect your wallet.</p>

--- a/frontend/src/routes/DAO/Treasury.svelte
+++ b/frontend/src/routes/DAO/Treasury.svelte
@@ -11,10 +11,7 @@
   } from "../../ts/daoStore";
   import { provider, userEthereumAddress } from "../../ts/ethStore";
   import { error, isSubmitting } from "../../ts/mainStore";
-  import {
-    checkUndefinedProvider,
-    ensureSameChainId,
-  } from "../../utils/ethHelpers";
+  import { checkUndefinedProvider } from "../../utils/ethHelpers";
   import formatDateTime from "../../utils/formatDateTime";
   import { secondsPerBlock } from "../../utils/futureBlockDate";
   import truncateEthAddress from "../../utils/truncateEthereumAddress";
@@ -65,10 +62,6 @@
 
     $isSubmitting = true;
   });
-
-  $: {
-    ensureSameChainId($daoConfig?.chainId);
-  }
 
   async function prepareView() {
     if (
@@ -149,7 +142,7 @@
   });
 </script>
 
-<Navigation>
+<Navigation requiresChainId={$daoConfig?.chainId}>
   <h1 class="text-secondary-900">Treasury</h1>
 
   <ul>

--- a/frontend/src/routes/DAO/Votes.svelte
+++ b/frontend/src/routes/DAO/Votes.svelte
@@ -13,10 +13,7 @@
   import { provider } from "../../ts/ethStore";
   import { isSubmitting } from "../../ts/mainStore";
   import { proposalStore, votingSlots } from "../../ts/proposalStore";
-  import {
-    checkUndefinedProvider,
-    ensureSameChainId,
-  } from "../../utils/ethHelpers";
+  import { checkUndefinedProvider } from "../../utils/ethHelpers";
   import formatDateTime from "../../utils/formatDateTime";
   import { futureBlockDate } from "../../utils/futureBlockDate";
   import truncateString from "../../utils/truncateString";
@@ -57,8 +54,6 @@
   checkUndefinedProvider();
 
   $: {
-    ensureSameChainId($daoConfig?.chainId);
-
     if (
       $currentBlockNumber === null ||
       $currentBlockTimestamp === null ||
@@ -194,7 +189,7 @@
   }
 </style>
 
-<Navigation>
+<Navigation requiresChainId={$daoConfig?.chainId}>
   <p>Last updated (block): #{$currentBlockNumber}</p>
   <p>
     Last updated (time): {currentTime}

--- a/frontend/src/routes/DifferentChainId.svelte
+++ b/frontend/src/routes/DifferentChainId.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import queryString from "query-string";
+  import { Link } from "svelte-routing";
+  import { lastEthRoute } from "../ts/ethStore";
 
   export let location;
 
@@ -14,8 +16,7 @@
       Your MetaMask browser plugin is currently connected to the network with ID {queryParams.actual}.
       However, FlatFeeStack requires to use {queryParams.required}. Please
       change your network in MetaMask and
-      <a href="javascript:history.back()">click here</a> to return to the previous
-      page.
+      <Link to={$lastEthRoute}>click here</Link> to return to the previous page.
     </p>
   </div>
 </div>

--- a/frontend/src/routes/Income.svelte
+++ b/frontend/src/routes/Income.svelte
@@ -7,7 +7,7 @@
   import { PayoutERC20ABI } from "../contracts/PayoutERC20";
   import { PayoutEthABI } from "../contracts/PayoutEth";
   import { API } from "../ts/api";
-  import { getChainId, provider, signer } from "../ts/ethStore";
+  import { getChainId, lastEthRoute, provider, signer } from "../ts/ethStore";
   import { error } from "../ts/mainStore";
   import { formatBalance, formatDate, timeSince } from "../ts/services";
   import type { PayoutResponse } from "../types/backend";
@@ -44,6 +44,7 @@
     if (currentChainId === undefined) {
       showMetaMaskRequired();
     } else if (currentChainId !== payoutConfig.chainId) {
+      $lastEthRoute = window.location.pathname;
       navigate(
         `/differentChainId?required=${payoutConfig.chainId}&actual=${currentChainId}`
       );

--- a/frontend/src/routes/Income.svelte
+++ b/frontend/src/routes/Income.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Contract, Signature } from "ethers";
+  import { BrowserProvider, Contract, Signature } from "ethers";
   import { onMount } from "svelte";
   import { navigate } from "svelte-routing";
   import Navigation from "../components/Navigation.svelte";
@@ -14,6 +14,7 @@
   import type { PayoutConfig } from "../types/payout";
   import setSigner from "../utils/setSigner";
   import showMetaMaskRequired from "../utils/showMetaMaskRequired";
+  import detectEthereumProvider from "@metamask/detect-provider";
 
   let ethSignature: Signature;
   let isLoading = false;
@@ -34,6 +35,13 @@
 
   async function doEthPayout() {
     isLoading = true;
+
+    try {
+      const ethProv = await detectEthereumProvider();
+      $provider = new BrowserProvider(<any>ethProv);
+    } catch (exception) {
+      $provider = undefined;
+    }
 
     if ($signer === null) {
       await setSigner($provider);

--- a/frontend/src/ts/daoStore.ts
+++ b/frontend/src/ts/daoStore.ts
@@ -43,9 +43,11 @@ export const currentBlockTimestamp = derived<
     ) {
       set(null);
     } else {
-      $provider.getBlock($currentBlockNumber).then((currentBlock) => {
-        set(currentBlock.timestamp);
-      });
+      Promise.resolve($provider.getBlock($currentBlockNumber)).then(
+        (currentBlock) => {
+          set(currentBlock.timestamp);
+        }
+      );
     }
   },
   null

--- a/frontend/src/ts/ethStore.ts
+++ b/frontend/src/ts/ethStore.ts
@@ -21,6 +21,24 @@ export const chainId = derived<Readable<BrowserProvider | null>, number | null>(
   }
 );
 
+// usually, we have the EnsureChainId component that listens and redirects if the chain ids do not match
+// however, in certain cases, we want to have a blocking function
+// like in the Income component, where we want to make sure that the chain id is the same before preparing the transaction to withdraw funds
+export function getChainId(): Promise<number | undefined> {
+  const timeoutPromise = new Promise<undefined>((resolve) =>
+    setTimeout(() => resolve(undefined), 5000)
+  );
+  const functionPromise = new Promise<number>((resolve) => {
+    chainId.subscribe((chainIdValue) => {
+      if (chainIdValue !== null) {
+        resolve(chainIdValue);
+      }
+    });
+  });
+
+  return Promise.race([functionPromise, timeoutPromise]);
+}
+
 export const userEthereumAddress = derived<
   Readable<JsonRpcSigner | null>,
   string | null

--- a/frontend/src/ts/ethStore.ts
+++ b/frontend/src/ts/ethStore.ts
@@ -1,5 +1,5 @@
 import type { BrowserProvider, JsonRpcSigner, Network } from "ethers";
-import { derived, writable, type Readable } from "svelte/store";
+import { derived, writable, type Readable, get } from "svelte/store";
 
 // provider is null when it's not initialized
 // undefined when we did not detect any provider
@@ -20,6 +20,7 @@ export const chainId = derived<Readable<BrowserProvider | null>, number | null>(
     }
   }
 );
+export const lastEthRoute = writable<string>("/");
 
 // usually, we have the EnsureChainId component that listens and redirects if the chain ids do not match
 // however, in certain cases, we want to have a blocking function
@@ -29,6 +30,12 @@ export function getChainId(): Promise<number | undefined> {
     setTimeout(() => resolve(undefined), 5000)
   );
   const functionPromise = new Promise<number>((resolve) => {
+    const currentStoreValue = get(chainId);
+    if (currentStoreValue !== null) {
+      resolve(currentStoreValue);
+      return;
+    }
+
     chainId.subscribe((chainIdValue) => {
       if (chainIdValue !== null) {
         resolve(chainIdValue);

--- a/frontend/src/utils/ethHelpers.ts
+++ b/frontend/src/utils/ethHelpers.ts
@@ -1,5 +1,4 @@
-import { navigate } from "svelte-routing";
-import { chainId, provider } from "../ts/ethStore";
+import { provider } from "../ts/ethStore";
 import showMetaMaskRequired from "./showMetaMaskRequired";
 
 export const checkUndefinedProvider = () =>
@@ -8,17 +7,3 @@ export const checkUndefinedProvider = () =>
       showMetaMaskRequired();
     }
   });
-
-export const ensureSameChainId = (requiredChainId: number | undefined) => {
-  if (requiredChainId === undefined) {
-    return;
-  }
-
-  chainId.subscribe((chainIdValue) => {
-    if (chainIdValue !== null && chainIdValue !== requiredChainId) {
-      navigate(
-        `/differentChainId?required=${requiredChainId}&actual=${chainIdValue}`
-      );
-    }
-  });
-};


### PR DESCRIPTION
The current implementation of "Ensure same chain ID" has a couple of issues:

1. The helper function did not react if a value was already filled into the respective `chainId` store.
2. The back link to the previous page did not work.
3. In the `Income` page, the function that prepares the MetaMask transaction did not terminate if a different chain id was detected, as `navigate` does not terminate the execution of the current function.

This PR refactors a couple of things to fix these issues.

1. Extract the `ensureSameChainId` into a component. This component is conditionally renderd in the DAO navigation. Child components of the DAO can communicate the required chain ID to the Navigation component if needed. For example, the discussion is also a child of the DAO navigation, but since it does not need the Ethereum blockchain, the required chain ID is not set. The component does the same as the helper function before, but leverages the `$` syntax offered by Svelte for components when interacting with stores.
2. For certain cases, like on the `Income` component or when connecting the MetaMask wallet to the DAO, a blocking function is required. `getChainId` returns a Promise of the current network ID. Those components also need to handle the redirect to `DifferentChainIds` themselves.
3. Before navigating to the page where we show the error about the different chain ids, a new store is written with the value of the current route that triggered the redirect to properly render the back button on said page. Note that this code could be simplified once we can update to svelte-routing v1.8, as they introduced a history mechanism in the library itself.
4. Unrelated to the issues in this branch, but `$provider` was sometimes not initialised on the Income page. This is fixed as well.