### PR TITLE
Use Node v18 in pipeline

### DIFF
--- a/.github/workflows/smart-contracts-eth.yaml
+++ b/.github/workflows/smart-contracts-eth.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version-file: "smart-contracts-eth/.nvmrc"
           cache: "npm"
           cache-dependency-path: smart-contracts-eth/package-lock.json
       - run: npm i

--- a/smart-contracts-eth/package-lock.json
+++ b/smart-contracts-eth/package-lock.json
@@ -13,7 +13,7 @@
         "@openzeppelin/hardhat-upgrades": "^1.28.0",
         "dotenv": "^16.2.0",
         "envfile": "^6.18.0",
-        "hardhat": "^2.15.0",
+        "hardhat": "^2.16.1",
         "hardhat-deploy": "^0.11.30",
         "hardhat-deploy-ethers": "^0.3.0-beta.13",
         "prettier": "^2.8.8",
@@ -5173,9 +5173,9 @@
       }
     },
     "node_modules/hardhat": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.15.0.tgz",
-      "integrity": "sha512-cC9tM/N10YaES04zPOp7yR13iX3YibqaNmi0//Ep40Nt9ELIJx3kFpQmucur0PAIfXYpGnw5RuXHNLkxpnVHEw==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.16.1.tgz",
+      "integrity": "sha512-QpBjGXFhhSYoYBGEHyoau/A63crZOP+i3GbNxzLGkL6IklzT+piN14+wGnINNCg5BLSKisQI/RAySPzaWRcx/g==",
       "dev": true,
       "dependencies": {
         "@ethersproject/abi": "^5.1.2",
@@ -5217,7 +5217,6 @@
         "mnemonist": "^0.38.0",
         "mocha": "^10.0.0",
         "p-map": "^4.0.0",
-        "qs": "^6.7.0",
         "raw-body": "^2.4.1",
         "resolve": "1.17.0",
         "semver": "^6.3.0",
@@ -13984,9 +13983,9 @@
       }
     },
     "hardhat": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.15.0.tgz",
-      "integrity": "sha512-cC9tM/N10YaES04zPOp7yR13iX3YibqaNmi0//Ep40Nt9ELIJx3kFpQmucur0PAIfXYpGnw5RuXHNLkxpnVHEw==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.16.1.tgz",
+      "integrity": "sha512-QpBjGXFhhSYoYBGEHyoau/A63crZOP+i3GbNxzLGkL6IklzT+piN14+wGnINNCg5BLSKisQI/RAySPzaWRcx/g==",
       "dev": true,
       "requires": {
         "@ethersproject/abi": "^5.1.2",
@@ -14028,7 +14027,6 @@
         "mnemonist": "^0.38.0",
         "mocha": "^10.0.0",
         "p-map": "^4.0.0",
-        "qs": "^6.7.0",
         "raw-body": "^2.4.1",
         "resolve": "1.17.0",
         "semver": "^6.3.0",

--- a/smart-contracts-eth/package-lock.json
+++ b/smart-contracts-eth/package-lock.json
@@ -19,7 +19,7 @@
         "prettier": "^2.8.8",
         "prettier-plugin-solidity": "^1.1.3",
         "solhint": "^3.4.1",
-        "solidity-coverage": "^0.8.2"
+        "solidity-coverage": "^0.8.4"
       }
     },
     "node_modules/@aws-crypto/sha256-js": {
@@ -2116,6 +2116,7 @@
       "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.14.5.tgz",
       "integrity": "sha512-6dKnHZn7fg/iQATVEzqyUOyEidbn05q7YA2mQ9hC0MMXhhV3/JrsxmFSYZAcr7j1yUP700LLhTruvJ3MiQmjJg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "antlr4ts": "^0.5.0-alpha.4"
       }
@@ -8287,13 +8288,13 @@
       "dev": true
     },
     "node_modules/solidity-coverage": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/solidity-coverage/-/solidity-coverage-0.8.2.tgz",
-      "integrity": "sha512-cv2bWb7lOXPE9/SSleDO6czkFiMHgP4NXPj+iW9W7iEKLBk7Cj0AGBiNmGX3V1totl9wjPrT0gHmABZKZt65rQ==",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/solidity-coverage/-/solidity-coverage-0.8.4.tgz",
+      "integrity": "sha512-xeHOfBOjdMF6hWTbt42iH4x+7j1Atmrf5OldDPMxI+i/COdExUxszOswD9qqvcBTaLGiOrrpnh9UZjSpt4rBsg==",
       "dev": true,
       "dependencies": {
         "@ethersproject/abi": "^5.0.9",
-        "@solidity-parser/parser": "^0.14.1",
+        "@solidity-parser/parser": "^0.16.0",
         "chalk": "^2.4.2",
         "death": "^1.1.0",
         "detect-port": "^1.3.0",
@@ -8318,6 +8319,15 @@
       },
       "peerDependencies": {
         "hardhat": "^2.11.0"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/@solidity-parser/parser": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.16.0.tgz",
+      "integrity": "sha512-ESipEcHyRHg4Np4SqBCfcXwyxxna1DgFVz69bgpLV8vzl/NP1DtcKsJ4dJZXWQhY/Z4J2LeKBiOkOVZn9ct33Q==",
+      "dev": true,
+      "dependencies": {
+        "antlr4ts": "^0.5.0-alpha.4"
       }
     },
     "node_modules/solidity-coverage/node_modules/ansi-colors": {
@@ -11525,6 +11535,7 @@
       "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.14.5.tgz",
       "integrity": "sha512-6dKnHZn7fg/iQATVEzqyUOyEidbn05q7YA2mQ9hC0MMXhhV3/JrsxmFSYZAcr7j1yUP700LLhTruvJ3MiQmjJg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "antlr4ts": "^0.5.0-alpha.4"
       }
@@ -16329,13 +16340,13 @@
       "dev": true
     },
     "solidity-coverage": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/solidity-coverage/-/solidity-coverage-0.8.2.tgz",
-      "integrity": "sha512-cv2bWb7lOXPE9/SSleDO6czkFiMHgP4NXPj+iW9W7iEKLBk7Cj0AGBiNmGX3V1totl9wjPrT0gHmABZKZt65rQ==",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/solidity-coverage/-/solidity-coverage-0.8.4.tgz",
+      "integrity": "sha512-xeHOfBOjdMF6hWTbt42iH4x+7j1Atmrf5OldDPMxI+i/COdExUxszOswD9qqvcBTaLGiOrrpnh9UZjSpt4rBsg==",
       "dev": true,
       "requires": {
         "@ethersproject/abi": "^5.0.9",
-        "@solidity-parser/parser": "^0.14.1",
+        "@solidity-parser/parser": "^0.16.0",
         "chalk": "^2.4.2",
         "death": "^1.1.0",
         "detect-port": "^1.3.0",
@@ -16356,6 +16367,15 @@
         "web3-utils": "^1.3.6"
       },
       "dependencies": {
+        "@solidity-parser/parser": {
+          "version": "0.16.0",
+          "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.16.0.tgz",
+          "integrity": "sha512-ESipEcHyRHg4Np4SqBCfcXwyxxna1DgFVz69bgpLV8vzl/NP1DtcKsJ4dJZXWQhY/Z4J2LeKBiOkOVZn9ct33Q==",
+          "dev": true,
+          "requires": {
+            "antlr4ts": "^0.5.0-alpha.4"
+          }
+        },
         "ansi-colors": {
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",

--- a/smart-contracts-eth/package.json
+++ b/smart-contracts-eth/package.json
@@ -9,7 +9,7 @@
     "@openzeppelin/hardhat-upgrades": "^1.28.0",
     "dotenv": "^16.2.0",
     "envfile": "^6.18.0",
-    "hardhat": "^2.15.0",
+    "hardhat": "^2.16.1",
     "hardhat-deploy": "^0.11.30",
     "hardhat-deploy-ethers": "^0.3.0-beta.13",
     "prettier": "^2.8.8",

--- a/smart-contracts-eth/package.json
+++ b/smart-contracts-eth/package.json
@@ -15,7 +15,7 @@
     "prettier": "^2.8.8",
     "prettier-plugin-solidity": "^1.1.3",
     "solhint": "^3.4.1",
-    "solidity-coverage": "^0.8.2"
+    "solidity-coverage": "^0.8.4"
   },
   "scripts": {
     "hardhat:test": "hardhat test",


### PR DESCRIPTION
We already had an `.nvmrc` in our repository specying Node v18, but on GitHub Actions, the value was hardcoded to v16. Upon upgrading the version, the Solidity compiler was not downloaded at all, same symptoms as described in https://github.com/sc-forks/solidity-coverage/issues/794.

Updating Hardhat to v2.16.1 and `solidity-coverage` to v0.8.4 according to https://github.com/sc-forks/solidity-coverage/issues/794#issuecomment-1620501269 worked. Now the Node version on GitHub Actions is already read from the `.nvmrc`, so they stay aligned.